### PR TITLE
Improve error output

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,7 +7,9 @@ const UNICODE_VERSION = require(
 
 const _template = require('lodash.template');
 const TEST_TEMPLATE = fs.readFileSync('templates/test.template', 'utf8');
-const template = _template(TEST_TEMPLATE);
+const template = _template(TEST_TEMPLATE, {
+	'interpolate': /<%=([\s\S]+?)%>/g
+});
 
 const escape = (value) => {
 	return jsesc(value, {

--- a/harness/regExpUtils.js
+++ b/harness/regExpUtils.js
@@ -14,3 +14,19 @@ function buildString({ loneCodePoints, ranges }) {
   }
   return result;
 }
+
+function testPropertyEscapes(regex, string, expression) {
+  if (!regex.test(string)) {
+    for (const symbol of string) {
+      const hex = symbol
+        .codePointAt(0)
+        .toString(16)
+        .toUpperCase()
+        .padStart(6, "0");
+      assert(
+        regex.test(symbol),
+        `\`${ expression }\` should match U+${ hex } (\`${ symbol }\`)`
+      );
+    }
+  }
+}

--- a/output/ASCII.js
+++ b/output/ASCII.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,9 +19,10 @@ const matchSymbols = buildString({
     [0x000000, 0x00007F]
   ]
 });
-assert(
-  /^\p{ASCII}+$/u.test(matchSymbols),
-  "`\\p{ASCII}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{ASCII}+$/u,
+  matchSymbols,
+  "\\p{ASCII}"
 );
 
 const nonMatchSymbols = buildString({
@@ -32,7 +33,8 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{ASCII}+$/u.test(nonMatchSymbols),
-  "`\\P{ASCII}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{ASCII}+$/u,
+  nonMatchSymbols,
+  "\\P{ASCII}"
 );

--- a/output/ASCII_Hex_Digit.js
+++ b/output/ASCII_Hex_Digit.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,13 +21,15 @@ const matchSymbols = buildString({
     [0x000061, 0x000066]
   ]
 });
-assert(
-  /^\p{ASCII_Hex_Digit}+$/u.test(matchSymbols),
-  "`\\p{ASCII_Hex_Digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{ASCII_Hex_Digit}+$/u,
+  matchSymbols,
+  "\\p{ASCII_Hex_Digit}"
 );
-assert(
-  /^\p{AHex}+$/u.test(matchSymbols),
-  "`\\p{AHex}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{AHex}+$/u,
+  matchSymbols,
+  "\\p{AHex}"
 );
 
 const nonMatchSymbols = buildString({
@@ -41,11 +43,13 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{ASCII_Hex_Digit}+$/u.test(nonMatchSymbols),
-  "`\\P{ASCII_Hex_Digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{ASCII_Hex_Digit}+$/u,
+  nonMatchSymbols,
+  "\\P{ASCII_Hex_Digit}"
 );
-assert(
-  /^\P{AHex}+$/u.test(nonMatchSymbols),
-  "`\\P{AHex}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{AHex}+$/u,
+  nonMatchSymbols,
+  "\\P{AHex}"
 );

--- a/output/Alphabetic.js
+++ b/output/Alphabetic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -663,13 +663,15 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{Alphabetic}+$/u.test(matchSymbols),
-  "`\\p{Alphabetic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Alphabetic}+$/u,
+  matchSymbols,
+  "\\p{Alphabetic}"
 );
-assert(
-  /^\p{Alpha}+$/u.test(matchSymbols),
-  "`\\p{Alpha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Alpha}+$/u,
+  matchSymbols,
+  "\\p{Alpha}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1325,11 +1327,13 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Alphabetic}+$/u.test(nonMatchSymbols),
-  "`\\P{Alphabetic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Alphabetic}+$/u,
+  nonMatchSymbols,
+  "\\P{Alphabetic}"
 );
-assert(
-  /^\P{Alpha}+$/u.test(nonMatchSymbols),
-  "`\\P{Alpha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Alpha}+$/u,
+  nonMatchSymbols,
+  "\\P{Alpha}"
 );

--- a/output/Any.js
+++ b/output/Any.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,12 +21,13 @@ const matchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\p{Any}+$/u.test(matchSymbols),
-  "`\\p{Any}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Any}+$/u,
+  matchSymbols,
+  "\\p{Any}"
 );
 
 assert(
   !/\P{Any}/u.test(""),
-  "`\\P{Any}` matches nothing (not even the empty string)"
+  "`\\P{Any}` should match nothing (not even the empty string)"
 );

--- a/output/Assigned.js
+++ b/output/Assigned.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -659,9 +659,10 @@ const matchSymbols = buildString({
     [0x100000, 0x10FFFD]
   ]
 });
-assert(
-  /^\p{Assigned}+$/u.test(matchSymbols),
-  "`\\p{Assigned}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Assigned}+$/u,
+  matchSymbols,
+  "\\p{Assigned}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1309,7 +1310,8 @@ const nonMatchSymbols = buildString({
     [0x10FFFE, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Assigned}+$/u.test(nonMatchSymbols),
-  "`\\P{Assigned}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Assigned}+$/u,
+  nonMatchSymbols,
+  "\\P{Assigned}"
 );

--- a/output/Bidi_Control.js
+++ b/output/Bidi_Control.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,13 +23,15 @@ const matchSymbols = buildString({
     [0x002066, 0x002069]
   ]
 });
-assert(
-  /^\p{Bidi_Control}+$/u.test(matchSymbols),
-  "`\\p{Bidi_Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Bidi_Control}+$/u,
+  matchSymbols,
+  "\\p{Bidi_Control}"
 );
-assert(
-  /^\p{Bidi_C}+$/u.test(matchSymbols),
-  "`\\p{Bidi_C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Bidi_C}+$/u,
+  matchSymbols,
+  "\\p{Bidi_C}"
 );
 
 const nonMatchSymbols = buildString({
@@ -44,11 +46,13 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Bidi_Control}+$/u.test(nonMatchSymbols),
-  "`\\P{Bidi_Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Bidi_Control}+$/u,
+  nonMatchSymbols,
+  "\\P{Bidi_Control}"
 );
-assert(
-  /^\P{Bidi_C}+$/u.test(nonMatchSymbols),
-  "`\\P{Bidi_C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Bidi_C}+$/u,
+  nonMatchSymbols,
+  "\\P{Bidi_C}"
 );

--- a/output/Bidi_Mirrored.js
+++ b/output/Bidi_Mirrored.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -130,13 +130,15 @@ const matchSymbols = buildString({
     [0x00FF62, 0x00FF63]
   ]
 });
-assert(
-  /^\p{Bidi_Mirrored}+$/u.test(matchSymbols),
-  "`\\p{Bidi_Mirrored}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Bidi_Mirrored}+$/u,
+  matchSymbols,
+  "\\p{Bidi_Mirrored}"
 );
-assert(
-  /^\p{Bidi_M}+$/u.test(matchSymbols),
-  "`\\p{Bidi_M}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Bidi_M}+$/u,
+  matchSymbols,
+  "\\p{Bidi_M}"
 );
 
 const nonMatchSymbols = buildString({
@@ -259,11 +261,13 @@ const nonMatchSymbols = buildString({
     [0x01D7C4, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Bidi_Mirrored}+$/u.test(nonMatchSymbols),
-  "`\\P{Bidi_Mirrored}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Bidi_Mirrored}+$/u,
+  nonMatchSymbols,
+  "\\P{Bidi_Mirrored}"
 );
-assert(
-  /^\P{Bidi_M}+$/u.test(nonMatchSymbols),
-  "`\\P{Bidi_M}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Bidi_M}+$/u,
+  nonMatchSymbols,
+  "\\P{Bidi_M}"
 );

--- a/output/Case_Ignorable.js
+++ b/output/Case_Ignorable.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -384,13 +384,15 @@ const matchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\p{Case_Ignorable}+$/u.test(matchSymbols),
-  "`\\p{Case_Ignorable}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Case_Ignorable}+$/u,
+  matchSymbols,
+  "\\p{Case_Ignorable}"
 );
-assert(
-  /^\p{CI}+$/u.test(matchSymbols),
-  "`\\p{CI}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{CI}+$/u,
+  matchSymbols,
+  "\\p{CI}"
 );
 
 const nonMatchSymbols = buildString({
@@ -767,11 +769,13 @@ const nonMatchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Case_Ignorable}+$/u.test(nonMatchSymbols),
-  "`\\P{Case_Ignorable}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Case_Ignorable}+$/u,
+  nonMatchSymbols,
+  "\\P{Case_Ignorable}"
 );
-assert(
-  /^\P{CI}+$/u.test(nonMatchSymbols),
-  "`\\P{CI}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{CI}+$/u,
+  nonMatchSymbols,
+  "\\P{CI}"
 );

--- a/output/Cased.js
+++ b/output/Cased.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -154,9 +154,10 @@ const matchSymbols = buildString({
     [0x01F170, 0x01F189]
   ]
 });
-assert(
-  /^\p{Cased}+$/u.test(matchSymbols),
-  "`\\p{Cased}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Cased}+$/u,
+  matchSymbols,
+  "\\p{Cased}"
 );
 
 const nonMatchSymbols = buildString({
@@ -303,7 +304,8 @@ const nonMatchSymbols = buildString({
     [0x01F18A, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Cased}+$/u.test(nonMatchSymbols),
-  "`\\P{Cased}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Cased}+$/u,
+  nonMatchSymbols,
+  "\\P{Cased}"
 );

--- a/output/Changes_When_Casefolded.js
+++ b/output/Changes_When_Casefolded.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -622,13 +622,15 @@ const matchSymbols = buildString({
     [0x01E900, 0x01E921]
   ]
 });
-assert(
-  /^\p{Changes_When_Casefolded}+$/u.test(matchSymbols),
-  "`\\p{Changes_When_Casefolded}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Changes_When_Casefolded}+$/u,
+  matchSymbols,
+  "\\p{Changes_When_Casefolded}"
 );
-assert(
-  /^\p{CWCF}+$/u.test(matchSymbols),
-  "`\\p{CWCF}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{CWCF}+$/u,
+  matchSymbols,
+  "\\p{CWCF}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1243,11 +1245,13 @@ const nonMatchSymbols = buildString({
     [0x01E922, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Changes_When_Casefolded}+$/u.test(nonMatchSymbols),
-  "`\\P{Changes_When_Casefolded}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Changes_When_Casefolded}+$/u,
+  nonMatchSymbols,
+  "\\P{Changes_When_Casefolded}"
 );
-assert(
-  /^\P{CWCF}+$/u.test(nonMatchSymbols),
-  "`\\P{CWCF}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{CWCF}+$/u,
+  nonMatchSymbols,
+  "\\P{CWCF}"
 );

--- a/output/Changes_When_Casemapped.js
+++ b/output/Changes_When_Casemapped.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -135,13 +135,15 @@ const matchSymbols = buildString({
     [0x01E900, 0x01E943]
   ]
 });
-assert(
-  /^\p{Changes_When_Casemapped}+$/u.test(matchSymbols),
-  "`\\p{Changes_When_Casemapped}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Changes_When_Casemapped}+$/u,
+  matchSymbols,
+  "\\p{Changes_When_Casemapped}"
 );
-assert(
-  /^\p{CWCM}+$/u.test(matchSymbols),
-  "`\\p{CWCM}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{CWCM}+$/u,
+  matchSymbols,
+  "\\p{CWCM}"
 );
 
 const nonMatchSymbols = buildString({
@@ -269,11 +271,13 @@ const nonMatchSymbols = buildString({
     [0x01E944, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Changes_When_Casemapped}+$/u.test(nonMatchSymbols),
-  "`\\P{Changes_When_Casemapped}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Changes_When_Casemapped}+$/u,
+  nonMatchSymbols,
+  "\\P{Changes_When_Casemapped}"
 );
-assert(
-  /^\P{CWCM}+$/u.test(nonMatchSymbols),
-  "`\\P{CWCM}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{CWCM}+$/u,
+  nonMatchSymbols,
+  "\\P{CWCM}"
 );

--- a/output/Changes_When_Lowercased.js
+++ b/output/Changes_When_Lowercased.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -609,13 +609,15 @@ const matchSymbols = buildString({
     [0x01E900, 0x01E921]
   ]
 });
-assert(
-  /^\p{Changes_When_Lowercased}+$/u.test(matchSymbols),
-  "`\\p{Changes_When_Lowercased}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Changes_When_Lowercased}+$/u,
+  matchSymbols,
+  "\\p{Changes_When_Lowercased}"
 );
-assert(
-  /^\p{CWL}+$/u.test(matchSymbols),
-  "`\\p{CWL}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{CWL}+$/u,
+  matchSymbols,
+  "\\p{CWL}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1217,11 +1219,13 @@ const nonMatchSymbols = buildString({
     [0x01E922, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Changes_When_Lowercased}+$/u.test(nonMatchSymbols),
-  "`\\P{Changes_When_Lowercased}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Changes_When_Lowercased}+$/u,
+  nonMatchSymbols,
+  "\\P{Changes_When_Lowercased}"
 );
-assert(
-  /^\P{CWL}+$/u.test(nonMatchSymbols),
-  "`\\P{CWL}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{CWL}+$/u,
+  nonMatchSymbols,
+  "\\P{CWL}"
 );

--- a/output/Changes_When_NFKC_Casefolded.js
+++ b/output/Changes_When_NFKC_Casefolded.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -834,13 +834,15 @@ const matchSymbols = buildString({
     [0x0E0000, 0x0E0FFF]
   ]
 });
-assert(
-  /^\p{Changes_When_NFKC_Casefolded}+$/u.test(matchSymbols),
-  "`\\p{Changes_When_NFKC_Casefolded}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Changes_When_NFKC_Casefolded}+$/u,
+  matchSymbols,
+  "\\p{Changes_When_NFKC_Casefolded}"
 );
-assert(
-  /^\p{CWKCF}+$/u.test(matchSymbols),
-  "`\\p{CWKCF}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{CWKCF}+$/u,
+  matchSymbols,
+  "\\p{CWKCF}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1667,11 +1669,13 @@ const nonMatchSymbols = buildString({
     [0x0E1000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Changes_When_NFKC_Casefolded}+$/u.test(nonMatchSymbols),
-  "`\\P{Changes_When_NFKC_Casefolded}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Changes_When_NFKC_Casefolded}+$/u,
+  nonMatchSymbols,
+  "\\P{Changes_When_NFKC_Casefolded}"
 );
-assert(
-  /^\P{CWKCF}+$/u.test(nonMatchSymbols),
-  "`\\P{CWKCF}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{CWKCF}+$/u,
+  nonMatchSymbols,
+  "\\P{CWKCF}"
 );

--- a/output/Changes_When_Titlecased.js
+++ b/output/Changes_When_Titlecased.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -627,13 +627,15 @@ const matchSymbols = buildString({
     [0x01E922, 0x01E943]
   ]
 });
-assert(
-  /^\p{Changes_When_Titlecased}+$/u.test(matchSymbols),
-  "`\\p{Changes_When_Titlecased}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Changes_When_Titlecased}+$/u,
+  matchSymbols,
+  "\\p{Changes_When_Titlecased}"
 );
-assert(
-  /^\p{CWT}+$/u.test(matchSymbols),
-  "`\\p{CWT}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{CWT}+$/u,
+  matchSymbols,
+  "\\p{CWT}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1253,11 +1255,13 @@ const nonMatchSymbols = buildString({
     [0x01E944, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Changes_When_Titlecased}+$/u.test(nonMatchSymbols),
-  "`\\P{Changes_When_Titlecased}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Changes_When_Titlecased}+$/u,
+  nonMatchSymbols,
+  "\\P{Changes_When_Titlecased}"
 );
-assert(
-  /^\P{CWT}+$/u.test(nonMatchSymbols),
-  "`\\P{CWT}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{CWT}+$/u,
+  nonMatchSymbols,
+  "\\P{CWT}"
 );

--- a/output/Changes_When_Uppercased.js
+++ b/output/Changes_When_Uppercased.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -626,13 +626,15 @@ const matchSymbols = buildString({
     [0x01E922, 0x01E943]
   ]
 });
-assert(
-  /^\p{Changes_When_Uppercased}+$/u.test(matchSymbols),
-  "`\\p{Changes_When_Uppercased}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Changes_When_Uppercased}+$/u,
+  matchSymbols,
+  "\\p{Changes_When_Uppercased}"
 );
-assert(
-  /^\p{CWU}+$/u.test(matchSymbols),
-  "`\\p{CWU}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{CWU}+$/u,
+  matchSymbols,
+  "\\p{CWU}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1251,11 +1253,13 @@ const nonMatchSymbols = buildString({
     [0x01E944, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Changes_When_Uppercased}+$/u.test(nonMatchSymbols),
-  "`\\P{Changes_When_Uppercased}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Changes_When_Uppercased}+$/u,
+  nonMatchSymbols,
+  "\\P{Changes_When_Uppercased}"
 );
-assert(
-  /^\P{CWU}+$/u.test(nonMatchSymbols),
-  "`\\P{CWU}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{CWU}+$/u,
+  nonMatchSymbols,
+  "\\P{CWU}"
 );

--- a/output/Composition_Exclusion.js
+++ b/output/Composition_Exclusion.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -52,13 +52,15 @@ const matchSymbols = buildString({
     [0x01D1BB, 0x01D1C0]
   ]
 });
-assert(
-  /^\p{Composition_Exclusion}+$/u.test(matchSymbols),
-  "`\\p{Composition_Exclusion}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Composition_Exclusion}+$/u,
+  matchSymbols,
+  "\\p{Composition_Exclusion}"
 );
-assert(
-  /^\p{CE}+$/u.test(matchSymbols),
-  "`\\p{CE}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{CE}+$/u,
+  matchSymbols,
+  "\\p{CE}"
 );
 
 const nonMatchSymbols = buildString({
@@ -103,11 +105,13 @@ const nonMatchSymbols = buildString({
     [0x01D1C1, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Composition_Exclusion}+$/u.test(nonMatchSymbols),
-  "`\\P{Composition_Exclusion}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Composition_Exclusion}+$/u,
+  nonMatchSymbols,
+  "\\P{Composition_Exclusion}"
 );
-assert(
-  /^\P{CE}+$/u.test(nonMatchSymbols),
-  "`\\P{CE}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{CE}+$/u,
+  nonMatchSymbols,
+  "\\P{CE}"
 );

--- a/output/Dash.js
+++ b/output/Dash.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -40,9 +40,10 @@ const matchSymbols = buildString({
     [0x00FE31, 0x00FE32]
   ]
 });
-assert(
-  /^\p{Dash}+$/u.test(matchSymbols),
-  "`\\p{Dash}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Dash}+$/u,
+  matchSymbols,
+  "\\p{Dash}"
 );
 
 const nonMatchSymbols = buildString({
@@ -74,7 +75,8 @@ const nonMatchSymbols = buildString({
     [0x00FF0E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Dash}+$/u.test(nonMatchSymbols),
-  "`\\P{Dash}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Dash}+$/u,
+  nonMatchSymbols,
+  "\\P{Dash}"
 );

--- a/output/Default_Ignorable_Code_Point.js
+++ b/output/Default_Ignorable_Code_Point.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -36,13 +36,15 @@ const matchSymbols = buildString({
     [0x0E0000, 0x0E0FFF]
   ]
 });
-assert(
-  /^\p{Default_Ignorable_Code_Point}+$/u.test(matchSymbols),
-  "`\\p{Default_Ignorable_Code_Point}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Default_Ignorable_Code_Point}+$/u,
+  matchSymbols,
+  "\\p{Default_Ignorable_Code_Point}"
 );
-assert(
-  /^\p{DI}+$/u.test(matchSymbols),
-  "`\\p{DI}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{DI}+$/u,
+  matchSymbols,
+  "\\p{DI}"
 );
 
 const nonMatchSymbols = buildString({
@@ -70,11 +72,13 @@ const nonMatchSymbols = buildString({
     [0x0E1000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Default_Ignorable_Code_Point}+$/u.test(nonMatchSymbols),
-  "`\\P{Default_Ignorable_Code_Point}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Default_Ignorable_Code_Point}+$/u,
+  nonMatchSymbols,
+  "\\P{Default_Ignorable_Code_Point}"
 );
-assert(
-  /^\P{DI}+$/u.test(nonMatchSymbols),
-  "`\\P{DI}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{DI}+$/u,
+  nonMatchSymbols,
+  "\\P{DI}"
 );

--- a/output/Deprecated.js
+++ b/output/Deprecated.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -27,13 +27,15 @@ const matchSymbols = buildString({
     [0x002329, 0x00232A]
   ]
 });
-assert(
-  /^\p{Deprecated}+$/u.test(matchSymbols),
-  "`\\p{Deprecated}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Deprecated}+$/u,
+  matchSymbols,
+  "\\p{Deprecated}"
 );
-assert(
-  /^\p{Dep}+$/u.test(matchSymbols),
-  "`\\p{Dep}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Dep}+$/u,
+  matchSymbols,
+  "\\p{Dep}"
 );
 
 const nonMatchSymbols = buildString({
@@ -53,11 +55,13 @@ const nonMatchSymbols = buildString({
     [0x0E0002, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Deprecated}+$/u.test(nonMatchSymbols),
-  "`\\P{Deprecated}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Deprecated}+$/u,
+  nonMatchSymbols,
+  "\\P{Deprecated}"
 );
-assert(
-  /^\P{Dep}+$/u.test(nonMatchSymbols),
-  "`\\P{Dep}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Dep}+$/u,
+  nonMatchSymbols,
+  "\\P{Dep}"
 );

--- a/output/Diacritic.js
+++ b/output/Diacritic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -171,13 +171,15 @@ const matchSymbols = buildString({
     [0x01E948, 0x01E94A]
   ]
 });
-assert(
-  /^\p{Diacritic}+$/u.test(matchSymbols),
-  "`\\p{Diacritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Diacritic}+$/u,
+  matchSymbols,
+  "\\p{Diacritic}"
 );
-assert(
-  /^\p{Dia}+$/u.test(matchSymbols),
-  "`\\p{Dia}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Dia}+$/u,
+  matchSymbols,
+  "\\p{Dia}"
 );
 
 const nonMatchSymbols = buildString({
@@ -341,11 +343,13 @@ const nonMatchSymbols = buildString({
     [0x01E94B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Diacritic}+$/u.test(nonMatchSymbols),
-  "`\\P{Diacritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Diacritic}+$/u,
+  nonMatchSymbols,
+  "\\P{Diacritic}"
 );
-assert(
-  /^\P{Dia}+$/u.test(nonMatchSymbols),
-  "`\\P{Dia}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Dia}+$/u,
+  nonMatchSymbols,
+  "\\P{Dia}"
 );

--- a/output/Emoji.js
+++ b/output/Emoji.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -164,9 +164,10 @@ const matchSymbols = buildString({
     [0x01F9D0, 0x01F9E6]
   ]
 });
-assert(
-  /^\p{Emoji}+$/u.test(matchSymbols),
-  "`\\p{Emoji}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Emoji}+$/u,
+  matchSymbols,
+  "\\p{Emoji}"
 );
 
 const nonMatchSymbols = buildString({
@@ -323,7 +324,8 @@ const nonMatchSymbols = buildString({
     [0x01F9E7, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Emoji}+$/u.test(nonMatchSymbols),
-  "`\\P{Emoji}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Emoji}+$/u,
+  nonMatchSymbols,
+  "\\P{Emoji}"
 );

--- a/output/Emoji_Component.js
+++ b/output/Emoji_Component.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -24,9 +24,10 @@ const matchSymbols = buildString({
     [0x01F3FB, 0x01F3FF]
   ]
 });
-assert(
-  /^\p{Emoji_Component}+$/u.test(matchSymbols),
-  "`\\p{Emoji_Component}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Emoji_Component}+$/u,
+  matchSymbols,
+  "\\p{Emoji_Component}"
 );
 
 const nonMatchSymbols = buildString({
@@ -42,7 +43,8 @@ const nonMatchSymbols = buildString({
     [0x01F400, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Emoji_Component}+$/u.test(nonMatchSymbols),
-  "`\\P{Emoji_Component}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Emoji_Component}+$/u,
+  nonMatchSymbols,
+  "\\P{Emoji_Component}"
 );

--- a/output/Emoji_Modifier.js
+++ b/output/Emoji_Modifier.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,9 +19,10 @@ const matchSymbols = buildString({
     [0x01F3FB, 0x01F3FF]
   ]
 });
-assert(
-  /^\p{Emoji_Modifier}+$/u.test(matchSymbols),
-  "`\\p{Emoji_Modifier}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Emoji_Modifier}+$/u,
+  matchSymbols,
+  "\\p{Emoji_Modifier}"
 );
 
 const nonMatchSymbols = buildString({
@@ -33,7 +34,8 @@ const nonMatchSymbols = buildString({
     [0x01F400, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Emoji_Modifier}+$/u.test(nonMatchSymbols),
-  "`\\P{Emoji_Modifier}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Emoji_Modifier}+$/u,
+  nonMatchSymbols,
+  "\\P{Emoji_Modifier}"
 );

--- a/output/Emoji_Modifier_Base.js
+++ b/output/Emoji_Modifier_Base.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -51,9 +51,10 @@ const matchSymbols = buildString({
     [0x01F9D1, 0x01F9DD]
   ]
 });
-assert(
-  /^\p{Emoji_Modifier_Base}+$/u.test(matchSymbols),
-  "`\\p{Emoji_Modifier_Base}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Emoji_Modifier_Base}+$/u,
+  matchSymbols,
+  "\\p{Emoji_Modifier_Base}"
 );
 
 const nonMatchSymbols = buildString({
@@ -97,7 +98,8 @@ const nonMatchSymbols = buildString({
     [0x01F9DE, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Emoji_Modifier_Base}+$/u.test(nonMatchSymbols),
-  "`\\P{Emoji_Modifier_Base}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Emoji_Modifier_Base}+$/u,
+  nonMatchSymbols,
+  "\\P{Emoji_Modifier_Base}"
 );

--- a/output/Emoji_Presentation.js
+++ b/output/Emoji_Presentation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -94,9 +94,10 @@ const matchSymbols = buildString({
     [0x01F9D0, 0x01F9E6]
   ]
 });
-assert(
-  /^\p{Emoji_Presentation}+$/u.test(matchSymbols),
-  "`\\p{Emoji_Presentation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Emoji_Presentation}+$/u,
+  matchSymbols,
+  "\\p{Emoji_Presentation}"
 );
 
 const nonMatchSymbols = buildString({
@@ -183,7 +184,8 @@ const nonMatchSymbols = buildString({
     [0x01F9E7, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Emoji_Presentation}+$/u.test(nonMatchSymbols),
-  "`\\P{Emoji_Presentation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Emoji_Presentation}+$/u,
+  nonMatchSymbols,
+  "\\P{Emoji_Presentation}"
 );

--- a/output/Extender.js
+++ b/output/Extender.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -47,13 +47,15 @@ const matchSymbols = buildString({
     [0x01E944, 0x01E946]
   ]
 });
-assert(
-  /^\p{Extender}+$/u.test(matchSymbols),
-  "`\\p{Extender}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Extender}+$/u,
+  matchSymbols,
+  "\\p{Extender}"
 );
-assert(
-  /^\p{Ext}+$/u.test(matchSymbols),
-  "`\\p{Ext}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Ext}+$/u,
+  matchSymbols,
+  "\\p{Ext}"
 );
 
 const nonMatchSymbols = buildString({
@@ -92,11 +94,13 @@ const nonMatchSymbols = buildString({
     [0x01E947, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Extender}+$/u.test(nonMatchSymbols),
-  "`\\P{Extender}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Extender}+$/u,
+  nonMatchSymbols,
+  "\\P{Extender}"
 );
-assert(
-  /^\P{Ext}+$/u.test(nonMatchSymbols),
-  "`\\P{Ext}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Ext}+$/u,
+  nonMatchSymbols,
+  "\\P{Ext}"
 );

--- a/output/Full_Composition_Exclusion.js
+++ b/output/Full_Composition_Exclusion.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -92,13 +92,15 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{Full_Composition_Exclusion}+$/u.test(matchSymbols),
-  "`\\p{Full_Composition_Exclusion}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Full_Composition_Exclusion}+$/u,
+  matchSymbols,
+  "\\p{Full_Composition_Exclusion}"
 );
-assert(
-  /^\p{Comp_Ex}+$/u.test(matchSymbols),
-  "`\\p{Comp_Ex}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Comp_Ex}+$/u,
+  matchSymbols,
+  "\\p{Comp_Ex}"
 );
 
 const nonMatchSymbols = buildString({
@@ -183,11 +185,13 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Full_Composition_Exclusion}+$/u.test(nonMatchSymbols),
-  "`\\P{Full_Composition_Exclusion}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Full_Composition_Exclusion}+$/u,
+  nonMatchSymbols,
+  "\\P{Full_Composition_Exclusion}"
 );
-assert(
-  /^\P{Comp_Ex}+$/u.test(nonMatchSymbols),
-  "`\\P{Comp_Ex}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Comp_Ex}+$/u,
+  nonMatchSymbols,
+  "\\P{Comp_Ex}"
 );

--- a/output/General_Category_-_Cased_Letter.js
+++ b/output/General_Category_-_Cased_Letter.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -145,29 +145,35 @@ const matchSymbols = buildString({
     [0x01E900, 0x01E943]
   ]
 });
-assert(
-  /^\p{General_Category=Cased_Letter}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Cased_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Cased_Letter}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Cased_Letter}"
 );
-assert(
-  /^\p{General_Category=LC}+$/u.test(matchSymbols),
-  "`\\p{General_Category=LC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=LC}+$/u,
+  matchSymbols,
+  "\\p{General_Category=LC}"
 );
-assert(
-  /^\p{gc=Cased_Letter}+$/u.test(matchSymbols),
-  "`\\p{gc=Cased_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Cased_Letter}+$/u,
+  matchSymbols,
+  "\\p{gc=Cased_Letter}"
 );
-assert(
-  /^\p{gc=LC}+$/u.test(matchSymbols),
-  "`\\p{gc=LC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=LC}+$/u,
+  matchSymbols,
+  "\\p{gc=LC}"
 );
-assert(
-  /^\p{Cased_Letter}+$/u.test(matchSymbols),
-  "`\\p{Cased_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Cased_Letter}+$/u,
+  matchSymbols,
+  "\\p{Cased_Letter}"
 );
-assert(
-  /^\p{LC}+$/u.test(matchSymbols),
-  "`\\p{LC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{LC}+$/u,
+  matchSymbols,
+  "\\p{LC}"
 );
 
 const nonMatchSymbols = buildString({
@@ -305,27 +311,33 @@ const nonMatchSymbols = buildString({
     [0x01E944, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Cased_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Cased_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Cased_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Cased_Letter}"
 );
-assert(
-  /^\P{General_Category=LC}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=LC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=LC}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=LC}"
 );
-assert(
-  /^\P{gc=Cased_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Cased_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Cased_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Cased_Letter}"
 );
-assert(
-  /^\P{gc=LC}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=LC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=LC}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=LC}"
 );
-assert(
-  /^\P{Cased_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{Cased_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Cased_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{Cased_Letter}"
 );
-assert(
-  /^\P{LC}+$/u.test(nonMatchSymbols),
-  "`\\P{LC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{LC}+$/u,
+  nonMatchSymbols,
+  "\\P{LC}"
 );

--- a/output/General_Category_-_Close_Punctuation.js
+++ b/output/General_Category_-_Close_Punctuation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -91,29 +91,35 @@ const matchSymbols = buildString({
     [0x00301E, 0x00301F]
   ]
 });
-assert(
-  /^\p{General_Category=Close_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Close_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Close_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Close_Punctuation}"
 );
-assert(
-  /^\p{General_Category=Pe}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Pe}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Pe}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Pe}"
 );
-assert(
-  /^\p{gc=Close_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{gc=Close_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Close_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{gc=Close_Punctuation}"
 );
-assert(
-  /^\p{gc=Pe}+$/u.test(matchSymbols),
-  "`\\p{gc=Pe}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Pe}+$/u,
+  matchSymbols,
+  "\\p{gc=Pe}"
 );
-assert(
-  /^\p{Close_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{Close_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Close_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{Close_Punctuation}"
 );
-assert(
-  /^\p{Pe}+$/u.test(matchSymbols),
-  "`\\p{Pe}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Pe}+$/u,
+  matchSymbols,
+  "\\p{Pe}"
 );
 
 const nonMatchSymbols = buildString({
@@ -197,27 +203,33 @@ const nonMatchSymbols = buildString({
     [0x00FF64, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Close_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Close_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Close_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Close_Punctuation}"
 );
-assert(
-  /^\P{General_Category=Pe}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Pe}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Pe}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Pe}"
 );
-assert(
-  /^\P{gc=Close_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Close_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Close_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Close_Punctuation}"
 );
-assert(
-  /^\P{gc=Pe}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Pe}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Pe}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Pe}"
 );
-assert(
-  /^\P{Close_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{Close_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Close_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{Close_Punctuation}"
 );
-assert(
-  /^\P{Pe}+$/u.test(nonMatchSymbols),
-  "`\\P{Pe}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Pe}+$/u,
+  nonMatchSymbols,
+  "\\P{Pe}"
 );

--- a/output/General_Category_-_Connector_Punctuation.js
+++ b/output/General_Category_-_Connector_Punctuation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,29 +25,35 @@ const matchSymbols = buildString({
     [0x00FE4D, 0x00FE4F]
   ]
 });
-assert(
-  /^\p{General_Category=Connector_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Connector_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Connector_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Connector_Punctuation}"
 );
-assert(
-  /^\p{General_Category=Pc}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Pc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Pc}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Pc}"
 );
-assert(
-  /^\p{gc=Connector_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{gc=Connector_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Connector_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{gc=Connector_Punctuation}"
 );
-assert(
-  /^\p{gc=Pc}+$/u.test(matchSymbols),
-  "`\\p{gc=Pc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Pc}+$/u,
+  matchSymbols,
+  "\\p{gc=Pc}"
 );
-assert(
-  /^\p{Connector_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{Connector_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Connector_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{Connector_Punctuation}"
 );
-assert(
-  /^\p{Pc}+$/u.test(matchSymbols),
-  "`\\p{Pc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Pc}+$/u,
+  matchSymbols,
+  "\\p{Pc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -64,27 +70,33 @@ const nonMatchSymbols = buildString({
     [0x00FF40, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Connector_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Connector_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Connector_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Connector_Punctuation}"
 );
-assert(
-  /^\P{General_Category=Pc}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Pc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Pc}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Pc}"
 );
-assert(
-  /^\P{gc=Connector_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Connector_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Connector_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Connector_Punctuation}"
 );
-assert(
-  /^\P{gc=Pc}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Pc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Pc}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Pc}"
 );
-assert(
-  /^\P{Connector_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{Connector_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Connector_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{Connector_Punctuation}"
 );
-assert(
-  /^\P{Pc}+$/u.test(nonMatchSymbols),
-  "`\\P{Pc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Pc}+$/u,
+  nonMatchSymbols,
+  "\\P{Pc}"
 );

--- a/output/General_Category_-_Control.js
+++ b/output/General_Category_-_Control.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,41 +20,50 @@ const matchSymbols = buildString({
     [0x00007F, 0x00009F]
   ]
 });
-assert(
-  /^\p{General_Category=Control}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Control}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Control}"
 );
-assert(
-  /^\p{General_Category=Cc}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Cc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Cc}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Cc}"
 );
-assert(
-  /^\p{General_Category=cntrl}+$/u.test(matchSymbols),
-  "`\\p{General_Category=cntrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=cntrl}+$/u,
+  matchSymbols,
+  "\\p{General_Category=cntrl}"
 );
-assert(
-  /^\p{gc=Control}+$/u.test(matchSymbols),
-  "`\\p{gc=Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Control}+$/u,
+  matchSymbols,
+  "\\p{gc=Control}"
 );
-assert(
-  /^\p{gc=Cc}+$/u.test(matchSymbols),
-  "`\\p{gc=Cc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Cc}+$/u,
+  matchSymbols,
+  "\\p{gc=Cc}"
 );
-assert(
-  /^\p{gc=cntrl}+$/u.test(matchSymbols),
-  "`\\p{gc=cntrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=cntrl}+$/u,
+  matchSymbols,
+  "\\p{gc=cntrl}"
 );
-assert(
-  /^\p{Control}+$/u.test(matchSymbols),
-  "`\\p{Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Control}+$/u,
+  matchSymbols,
+  "\\p{Control}"
 );
-assert(
-  /^\p{Cc}+$/u.test(matchSymbols),
-  "`\\p{Cc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Cc}+$/u,
+  matchSymbols,
+  "\\p{Cc}"
 );
-assert(
-  /^\p{cntrl}+$/u.test(matchSymbols),
-  "`\\p{cntrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{cntrl}+$/u,
+  matchSymbols,
+  "\\p{cntrl}"
 );
 
 const nonMatchSymbols = buildString({
@@ -66,39 +75,48 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Control}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Control}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Control}"
 );
-assert(
-  /^\P{General_Category=Cc}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Cc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Cc}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Cc}"
 );
-assert(
-  /^\P{General_Category=cntrl}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=cntrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=cntrl}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=cntrl}"
 );
-assert(
-  /^\P{gc=Control}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Control}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Control}"
 );
-assert(
-  /^\P{gc=Cc}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Cc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Cc}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Cc}"
 );
-assert(
-  /^\P{gc=cntrl}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=cntrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=cntrl}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=cntrl}"
 );
-assert(
-  /^\P{Control}+$/u.test(nonMatchSymbols),
-  "`\\P{Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Control}+$/u,
+  nonMatchSymbols,
+  "\\P{Control}"
 );
-assert(
-  /^\P{Cc}+$/u.test(nonMatchSymbols),
-  "`\\P{Cc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Cc}+$/u,
+  nonMatchSymbols,
+  "\\P{Cc}"
 );
-assert(
-  /^\P{cntrl}+$/u.test(nonMatchSymbols),
-  "`\\P{cntrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{cntrl}+$/u,
+  nonMatchSymbols,
+  "\\P{cntrl}"
 );

--- a/output/General_Category_-_Currency_Symbol.js
+++ b/output/General_Category_-_Currency_Symbol.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -36,29 +36,35 @@ const matchSymbols = buildString({
     [0x00FFE5, 0x00FFE6]
   ]
 });
-assert(
-  /^\p{General_Category=Currency_Symbol}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Currency_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Currency_Symbol}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Currency_Symbol}"
 );
-assert(
-  /^\p{General_Category=Sc}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Sc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Sc}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Sc}"
 );
-assert(
-  /^\p{gc=Currency_Symbol}+$/u.test(matchSymbols),
-  "`\\p{gc=Currency_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Currency_Symbol}+$/u,
+  matchSymbols,
+  "\\p{gc=Currency_Symbol}"
 );
-assert(
-  /^\p{gc=Sc}+$/u.test(matchSymbols),
-  "`\\p{gc=Sc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Sc}+$/u,
+  matchSymbols,
+  "\\p{gc=Sc}"
 );
-assert(
-  /^\p{Currency_Symbol}+$/u.test(matchSymbols),
-  "`\\p{Currency_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Currency_Symbol}+$/u,
+  matchSymbols,
+  "\\p{Currency_Symbol}"
 );
-assert(
-  /^\p{Sc}+$/u.test(matchSymbols),
-  "`\\p{Sc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Sc}+$/u,
+  matchSymbols,
+  "\\p{Sc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -86,27 +92,33 @@ const nonMatchSymbols = buildString({
     [0x00FFE7, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Currency_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Currency_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Currency_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Currency_Symbol}"
 );
-assert(
-  /^\P{General_Category=Sc}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Sc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Sc}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Sc}"
 );
-assert(
-  /^\P{gc=Currency_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Currency_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Currency_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Currency_Symbol}"
 );
-assert(
-  /^\P{gc=Sc}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Sc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Sc}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Sc}"
 );
-assert(
-  /^\P{Currency_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{Currency_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Currency_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{Currency_Symbol}"
 );
-assert(
-  /^\P{Sc}+$/u.test(nonMatchSymbols),
-  "`\\P{Sc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Sc}+$/u,
+  nonMatchSymbols,
+  "\\P{Sc}"
 );

--- a/output/General_Category_-_Dash_Punctuation.js
+++ b/output/General_Category_-_Dash_Punctuation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -36,29 +36,35 @@ const matchSymbols = buildString({
     [0x00FE31, 0x00FE32]
   ]
 });
-assert(
-  /^\p{General_Category=Dash_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Dash_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Dash_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Dash_Punctuation}"
 );
-assert(
-  /^\p{General_Category=Pd}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Pd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Pd}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Pd}"
 );
-assert(
-  /^\p{gc=Dash_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{gc=Dash_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Dash_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{gc=Dash_Punctuation}"
 );
-assert(
-  /^\p{gc=Pd}+$/u.test(matchSymbols),
-  "`\\p{gc=Pd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Pd}+$/u,
+  matchSymbols,
+  "\\p{gc=Pd}"
 );
-assert(
-  /^\p{Dash_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{Dash_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Dash_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{Dash_Punctuation}"
 );
-assert(
-  /^\p{Pd}+$/u.test(matchSymbols),
-  "`\\p{Pd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Pd}+$/u,
+  matchSymbols,
+  "\\p{Pd}"
 );
 
 const nonMatchSymbols = buildString({
@@ -86,27 +92,33 @@ const nonMatchSymbols = buildString({
     [0x00FF0E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Dash_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Dash_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Dash_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Dash_Punctuation}"
 );
-assert(
-  /^\P{General_Category=Pd}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Pd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Pd}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Pd}"
 );
-assert(
-  /^\P{gc=Dash_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Dash_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Dash_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Dash_Punctuation}"
 );
-assert(
-  /^\P{gc=Pd}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Pd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Pd}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Pd}"
 );
-assert(
-  /^\P{Dash_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{Dash_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Dash_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{Dash_Punctuation}"
 );
-assert(
-  /^\P{Pd}+$/u.test(nonMatchSymbols),
-  "`\\P{Pd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Pd}+$/u,
+  nonMatchSymbols,
+  "\\P{Pd}"
 );

--- a/output/General_Category_-_Decimal_Number.js
+++ b/output/General_Category_-_Decimal_Number.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -72,41 +72,50 @@ const matchSymbols = buildString({
     [0x01E950, 0x01E959]
   ]
 });
-assert(
-  /^\p{General_Category=Decimal_Number}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Decimal_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Decimal_Number}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Decimal_Number}"
 );
-assert(
-  /^\p{General_Category=Nd}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Nd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Nd}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Nd}"
 );
-assert(
-  /^\p{General_Category=digit}+$/u.test(matchSymbols),
-  "`\\p{General_Category=digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=digit}+$/u,
+  matchSymbols,
+  "\\p{General_Category=digit}"
 );
-assert(
-  /^\p{gc=Decimal_Number}+$/u.test(matchSymbols),
-  "`\\p{gc=Decimal_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Decimal_Number}+$/u,
+  matchSymbols,
+  "\\p{gc=Decimal_Number}"
 );
-assert(
-  /^\p{gc=Nd}+$/u.test(matchSymbols),
-  "`\\p{gc=Nd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Nd}+$/u,
+  matchSymbols,
+  "\\p{gc=Nd}"
 );
-assert(
-  /^\p{gc=digit}+$/u.test(matchSymbols),
-  "`\\p{gc=digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=digit}+$/u,
+  matchSymbols,
+  "\\p{gc=digit}"
 );
-assert(
-  /^\p{Decimal_Number}+$/u.test(matchSymbols),
-  "`\\p{Decimal_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Decimal_Number}+$/u,
+  matchSymbols,
+  "\\p{Decimal_Number}"
 );
-assert(
-  /^\p{Nd}+$/u.test(matchSymbols),
-  "`\\p{Nd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Nd}+$/u,
+  matchSymbols,
+  "\\p{Nd}"
 );
-assert(
-  /^\p{digit}+$/u.test(matchSymbols),
-  "`\\p{digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{digit}+$/u,
+  matchSymbols,
+  "\\p{digit}"
 );
 
 const nonMatchSymbols = buildString({
@@ -171,39 +180,48 @@ const nonMatchSymbols = buildString({
     [0x01E95A, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Decimal_Number}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Decimal_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Decimal_Number}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Decimal_Number}"
 );
-assert(
-  /^\P{General_Category=Nd}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Nd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Nd}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Nd}"
 );
-assert(
-  /^\P{General_Category=digit}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=digit}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=digit}"
 );
-assert(
-  /^\P{gc=Decimal_Number}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Decimal_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Decimal_Number}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Decimal_Number}"
 );
-assert(
-  /^\P{gc=Nd}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Nd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Nd}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Nd}"
 );
-assert(
-  /^\P{gc=digit}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=digit}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=digit}"
 );
-assert(
-  /^\P{Decimal_Number}+$/u.test(nonMatchSymbols),
-  "`\\P{Decimal_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Decimal_Number}+$/u,
+  nonMatchSymbols,
+  "\\P{Decimal_Number}"
 );
-assert(
-  /^\P{Nd}+$/u.test(nonMatchSymbols),
-  "`\\P{Nd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Nd}+$/u,
+  nonMatchSymbols,
+  "\\P{Nd}"
 );
-assert(
-  /^\P{digit}+$/u.test(nonMatchSymbols),
-  "`\\P{digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{digit}+$/u,
+  nonMatchSymbols,
+  "\\P{digit}"
 );

--- a/output/General_Category_-_Enclosing_Mark.js
+++ b/output/General_Category_-_Enclosing_Mark.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -24,29 +24,35 @@ const matchSymbols = buildString({
     [0x00A670, 0x00A672]
   ]
 });
-assert(
-  /^\p{General_Category=Enclosing_Mark}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Enclosing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Enclosing_Mark}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Enclosing_Mark}"
 );
-assert(
-  /^\p{General_Category=Me}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Me}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Me}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Me}"
 );
-assert(
-  /^\p{gc=Enclosing_Mark}+$/u.test(matchSymbols),
-  "`\\p{gc=Enclosing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Enclosing_Mark}+$/u,
+  matchSymbols,
+  "\\p{gc=Enclosing_Mark}"
 );
-assert(
-  /^\p{gc=Me}+$/u.test(matchSymbols),
-  "`\\p{gc=Me}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Me}+$/u,
+  matchSymbols,
+  "\\p{gc=Me}"
 );
-assert(
-  /^\p{Enclosing_Mark}+$/u.test(matchSymbols),
-  "`\\p{Enclosing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Enclosing_Mark}+$/u,
+  matchSymbols,
+  "\\p{Enclosing_Mark}"
 );
-assert(
-  /^\p{Me}+$/u.test(matchSymbols),
-  "`\\p{Me}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Me}+$/u,
+  matchSymbols,
+  "\\p{Me}"
 );
 
 const nonMatchSymbols = buildString({
@@ -63,27 +69,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Enclosing_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Enclosing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Enclosing_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Enclosing_Mark}"
 );
-assert(
-  /^\P{General_Category=Me}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Me}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Me}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Me}"
 );
-assert(
-  /^\P{gc=Enclosing_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Enclosing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Enclosing_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Enclosing_Mark}"
 );
-assert(
-  /^\P{gc=Me}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Me}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Me}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Me}"
 );
-assert(
-  /^\P{Enclosing_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{Enclosing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Enclosing_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{Enclosing_Mark}"
 );
-assert(
-  /^\P{Me}+$/u.test(nonMatchSymbols),
-  "`\\P{Me}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Me}+$/u,
+  nonMatchSymbols,
+  "\\P{Me}"
 );

--- a/output/General_Category_-_Final_Punctuation.js
+++ b/output/General_Category_-_Final_Punctuation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -28,29 +28,35 @@ const matchSymbols = buildString({
   ],
   ranges: []
 });
-assert(
-  /^\p{General_Category=Final_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Final_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Final_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Final_Punctuation}"
 );
-assert(
-  /^\p{General_Category=Pf}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Pf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Pf}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Pf}"
 );
-assert(
-  /^\p{gc=Final_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{gc=Final_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Final_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{gc=Final_Punctuation}"
 );
-assert(
-  /^\p{gc=Pf}+$/u.test(matchSymbols),
-  "`\\p{gc=Pf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Pf}+$/u,
+  matchSymbols,
+  "\\p{gc=Pf}"
 );
-assert(
-  /^\p{Final_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{Final_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Final_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{Final_Punctuation}"
 );
-assert(
-  /^\p{Pf}+$/u.test(matchSymbols),
-  "`\\p{Pf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Pf}+$/u,
+  matchSymbols,
+  "\\p{Pf}"
 );
 
 const nonMatchSymbols = buildString({
@@ -72,27 +78,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Final_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Final_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Final_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Final_Punctuation}"
 );
-assert(
-  /^\P{General_Category=Pf}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Pf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Pf}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Pf}"
 );
-assert(
-  /^\P{gc=Final_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Final_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Final_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Final_Punctuation}"
 );
-assert(
-  /^\P{gc=Pf}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Pf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Pf}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Pf}"
 );
-assert(
-  /^\P{Final_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{Final_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Final_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{Final_Punctuation}"
 );
-assert(
-  /^\P{Pf}+$/u.test(nonMatchSymbols),
-  "`\\P{Pf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Pf}+$/u,
+  nonMatchSymbols,
+  "\\P{Pf}"
 );

--- a/output/General_Category_-_Format.js
+++ b/output/General_Category_-_Format.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -37,29 +37,35 @@ const matchSymbols = buildString({
     [0x0E0020, 0x0E007F]
   ]
 });
-assert(
-  /^\p{General_Category=Format}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Format}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Format}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Format}"
 );
-assert(
-  /^\p{General_Category=Cf}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Cf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Cf}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Cf}"
 );
-assert(
-  /^\p{gc=Format}+$/u.test(matchSymbols),
-  "`\\p{gc=Format}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Format}+$/u,
+  matchSymbols,
+  "\\p{gc=Format}"
 );
-assert(
-  /^\p{gc=Cf}+$/u.test(matchSymbols),
-  "`\\p{gc=Cf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Cf}+$/u,
+  matchSymbols,
+  "\\p{gc=Cf}"
 );
-assert(
-  /^\p{Format}+$/u.test(matchSymbols),
-  "`\\p{Format}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Format}+$/u,
+  matchSymbols,
+  "\\p{Format}"
 );
-assert(
-  /^\p{Cf}+$/u.test(matchSymbols),
-  "`\\p{Cf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Cf}+$/u,
+  matchSymbols,
+  "\\p{Cf}"
 );
 
 const nonMatchSymbols = buildString({
@@ -89,27 +95,33 @@ const nonMatchSymbols = buildString({
     [0x0E0080, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Format}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Format}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Format}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Format}"
 );
-assert(
-  /^\P{General_Category=Cf}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Cf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Cf}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Cf}"
 );
-assert(
-  /^\P{gc=Format}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Format}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Format}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Format}"
 );
-assert(
-  /^\P{gc=Cf}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Cf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Cf}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Cf}"
 );
-assert(
-  /^\P{Format}+$/u.test(nonMatchSymbols),
-  "`\\P{Format}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Format}+$/u,
+  nonMatchSymbols,
+  "\\P{Format}"
 );
-assert(
-  /^\P{Cf}+$/u.test(nonMatchSymbols),
-  "`\\P{Cf}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Cf}+$/u,
+  nonMatchSymbols,
+  "\\P{Cf}"
 );

--- a/output/General_Category_-_Initial_Punctuation.js
+++ b/output/General_Category_-_Initial_Punctuation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -30,29 +30,35 @@ const matchSymbols = buildString({
     [0x00201B, 0x00201C]
   ]
 });
-assert(
-  /^\p{General_Category=Initial_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Initial_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Initial_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Initial_Punctuation}"
 );
-assert(
-  /^\p{General_Category=Pi}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Pi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Pi}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Pi}"
 );
-assert(
-  /^\p{gc=Initial_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{gc=Initial_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Initial_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{gc=Initial_Punctuation}"
 );
-assert(
-  /^\p{gc=Pi}+$/u.test(matchSymbols),
-  "`\\p{gc=Pi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Pi}+$/u,
+  matchSymbols,
+  "\\p{gc=Pi}"
 );
-assert(
-  /^\p{Initial_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{Initial_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Initial_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{Initial_Punctuation}"
 );
-assert(
-  /^\p{Pi}+$/u.test(matchSymbols),
-  "`\\p{Pi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Pi}+$/u,
+  matchSymbols,
+  "\\p{Pi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -75,27 +81,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Initial_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Initial_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Initial_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Initial_Punctuation}"
 );
-assert(
-  /^\P{General_Category=Pi}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Pi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Pi}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Pi}"
 );
-assert(
-  /^\P{gc=Initial_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Initial_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Initial_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Initial_Punctuation}"
 );
-assert(
-  /^\P{gc=Pi}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Pi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Pi}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Pi}"
 );
-assert(
-  /^\P{Initial_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{Initial_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Initial_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{Initial_Punctuation}"
 );
-assert(
-  /^\P{Pi}+$/u.test(nonMatchSymbols),
-  "`\\P{Pi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Pi}+$/u,
+  nonMatchSymbols,
+  "\\P{Pi}"
 );

--- a/output/General_Category_-_Letter.js
+++ b/output/General_Category_-_Letter.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -590,29 +590,35 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{General_Category=Letter}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Letter}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Letter}"
 );
-assert(
-  /^\p{General_Category=L}+$/u.test(matchSymbols),
-  "`\\p{General_Category=L}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=L}+$/u,
+  matchSymbols,
+  "\\p{General_Category=L}"
 );
-assert(
-  /^\p{gc=Letter}+$/u.test(matchSymbols),
-  "`\\p{gc=Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Letter}+$/u,
+  matchSymbols,
+  "\\p{gc=Letter}"
 );
-assert(
-  /^\p{gc=L}+$/u.test(matchSymbols),
-  "`\\p{gc=L}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=L}+$/u,
+  matchSymbols,
+  "\\p{gc=L}"
 );
-assert(
-  /^\p{Letter}+$/u.test(matchSymbols),
-  "`\\p{Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Letter}+$/u,
+  matchSymbols,
+  "\\p{Letter}"
 );
-assert(
-  /^\p{L}+$/u.test(matchSymbols),
-  "`\\p{L}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{L}+$/u,
+  matchSymbols,
+  "\\p{L}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1195,27 +1201,33 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Letter}"
 );
-assert(
-  /^\P{General_Category=L}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=L}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=L}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=L}"
 );
-assert(
-  /^\P{gc=Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Letter}"
 );
-assert(
-  /^\P{gc=L}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=L}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=L}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=L}"
 );
-assert(
-  /^\P{Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{Letter}"
 );
-assert(
-  /^\P{L}+$/u.test(nonMatchSymbols),
-  "`\\P{L}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{L}+$/u,
+  nonMatchSymbols,
+  "\\P{L}"
 );

--- a/output/General_Category_-_Letter_Number.js
+++ b/output/General_Category_-_Letter_Number.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -31,29 +31,35 @@ const matchSymbols = buildString({
     [0x012400, 0x01246E]
   ]
 });
-assert(
-  /^\p{General_Category=Letter_Number}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Letter_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Letter_Number}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Letter_Number}"
 );
-assert(
-  /^\p{General_Category=Nl}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Nl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Nl}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Nl}"
 );
-assert(
-  /^\p{gc=Letter_Number}+$/u.test(matchSymbols),
-  "`\\p{gc=Letter_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Letter_Number}+$/u,
+  matchSymbols,
+  "\\p{gc=Letter_Number}"
 );
-assert(
-  /^\p{gc=Nl}+$/u.test(matchSymbols),
-  "`\\p{gc=Nl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Nl}+$/u,
+  matchSymbols,
+  "\\p{gc=Nl}"
 );
-assert(
-  /^\p{Letter_Number}+$/u.test(matchSymbols),
-  "`\\p{Letter_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Letter_Number}+$/u,
+  matchSymbols,
+  "\\p{Letter_Number}"
 );
-assert(
-  /^\p{Nl}+$/u.test(matchSymbols),
-  "`\\p{Nl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Nl}+$/u,
+  matchSymbols,
+  "\\p{Nl}"
 );
 
 const nonMatchSymbols = buildString({
@@ -76,27 +82,33 @@ const nonMatchSymbols = buildString({
     [0x01246F, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Letter_Number}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Letter_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Letter_Number}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Letter_Number}"
 );
-assert(
-  /^\P{General_Category=Nl}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Nl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Nl}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Nl}"
 );
-assert(
-  /^\P{gc=Letter_Number}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Letter_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Letter_Number}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Letter_Number}"
 );
-assert(
-  /^\P{gc=Nl}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Nl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Nl}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Nl}"
 );
-assert(
-  /^\P{Letter_Number}+$/u.test(nonMatchSymbols),
-  "`\\P{Letter_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Letter_Number}+$/u,
+  nonMatchSymbols,
+  "\\P{Letter_Number}"
 );
-assert(
-  /^\P{Nl}+$/u.test(nonMatchSymbols),
-  "`\\P{Nl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Nl}+$/u,
+  nonMatchSymbols,
+  "\\P{Nl}"
 );

--- a/output/General_Category_-_Line_Separator.js
+++ b/output/General_Category_-_Line_Separator.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,29 +19,35 @@ const matchSymbols = buildString({
   ],
   ranges: []
 });
-assert(
-  /^\p{General_Category=Line_Separator}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Line_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Line_Separator}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Line_Separator}"
 );
-assert(
-  /^\p{General_Category=Zl}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Zl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Zl}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Zl}"
 );
-assert(
-  /^\p{gc=Line_Separator}+$/u.test(matchSymbols),
-  "`\\p{gc=Line_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Line_Separator}+$/u,
+  matchSymbols,
+  "\\p{gc=Line_Separator}"
 );
-assert(
-  /^\p{gc=Zl}+$/u.test(matchSymbols),
-  "`\\p{gc=Zl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Zl}+$/u,
+  matchSymbols,
+  "\\p{gc=Zl}"
 );
-assert(
-  /^\p{Line_Separator}+$/u.test(matchSymbols),
-  "`\\p{Line_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Line_Separator}+$/u,
+  matchSymbols,
+  "\\p{Line_Separator}"
 );
-assert(
-  /^\p{Zl}+$/u.test(matchSymbols),
-  "`\\p{Zl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Zl}+$/u,
+  matchSymbols,
+  "\\p{Zl}"
 );
 
 const nonMatchSymbols = buildString({
@@ -53,27 +59,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Line_Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Line_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Line_Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Line_Separator}"
 );
-assert(
-  /^\P{General_Category=Zl}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Zl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Zl}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Zl}"
 );
-assert(
-  /^\P{gc=Line_Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Line_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Line_Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Line_Separator}"
 );
-assert(
-  /^\P{gc=Zl}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Zl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Zl}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Zl}"
 );
-assert(
-  /^\P{Line_Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{Line_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Line_Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{Line_Separator}"
 );
-assert(
-  /^\P{Zl}+$/u.test(nonMatchSymbols),
-  "`\\P{Zl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Zl}+$/u,
+  nonMatchSymbols,
+  "\\P{Zl}"
 );

--- a/output/General_Category_-_Lowercase_Letter.js
+++ b/output/General_Category_-_Lowercase_Letter.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -652,29 +652,35 @@ const matchSymbols = buildString({
     [0x01E922, 0x01E943]
   ]
 });
-assert(
-  /^\p{General_Category=Lowercase_Letter}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Lowercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Lowercase_Letter}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Lowercase_Letter}"
 );
-assert(
-  /^\p{General_Category=Ll}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Ll}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Ll}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Ll}"
 );
-assert(
-  /^\p{gc=Lowercase_Letter}+$/u.test(matchSymbols),
-  "`\\p{gc=Lowercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Lowercase_Letter}+$/u,
+  matchSymbols,
+  "\\p{gc=Lowercase_Letter}"
 );
-assert(
-  /^\p{gc=Ll}+$/u.test(matchSymbols),
-  "`\\p{gc=Ll}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Ll}+$/u,
+  matchSymbols,
+  "\\p{gc=Ll}"
 );
-assert(
-  /^\p{Lowercase_Letter}+$/u.test(matchSymbols),
-  "`\\p{Lowercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Lowercase_Letter}+$/u,
+  matchSymbols,
+  "\\p{Lowercase_Letter}"
 );
-assert(
-  /^\p{Ll}+$/u.test(matchSymbols),
-  "`\\p{Ll}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Ll}+$/u,
+  matchSymbols,
+  "\\p{Ll}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1319,27 +1325,33 @@ const nonMatchSymbols = buildString({
     [0x01E944, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Lowercase_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Lowercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Lowercase_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Lowercase_Letter}"
 );
-assert(
-  /^\P{General_Category=Ll}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Ll}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Ll}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Ll}"
 );
-assert(
-  /^\P{gc=Lowercase_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Lowercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Lowercase_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Lowercase_Letter}"
 );
-assert(
-  /^\P{gc=Ll}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Ll}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Ll}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Ll}"
 );
-assert(
-  /^\P{Lowercase_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{Lowercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Lowercase_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{Lowercase_Letter}"
 );
-assert(
-  /^\P{Ll}+$/u.test(nonMatchSymbols),
-  "`\\P{Ll}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Ll}+$/u,
+  nonMatchSymbols,
+  "\\P{Ll}"
 );

--- a/output/General_Category_-_Mark.js
+++ b/output/General_Category_-_Mark.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -269,41 +269,50 @@ const matchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\p{General_Category=Mark}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Mark}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Mark}"
 );
-assert(
-  /^\p{General_Category=M}+$/u.test(matchSymbols),
-  "`\\p{General_Category=M}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=M}+$/u,
+  matchSymbols,
+  "\\p{General_Category=M}"
 );
-assert(
-  /^\p{General_Category=Combining_Mark}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Combining_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Combining_Mark}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Combining_Mark}"
 );
-assert(
-  /^\p{gc=Mark}+$/u.test(matchSymbols),
-  "`\\p{gc=Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Mark}+$/u,
+  matchSymbols,
+  "\\p{gc=Mark}"
 );
-assert(
-  /^\p{gc=M}+$/u.test(matchSymbols),
-  "`\\p{gc=M}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=M}+$/u,
+  matchSymbols,
+  "\\p{gc=M}"
 );
-assert(
-  /^\p{gc=Combining_Mark}+$/u.test(matchSymbols),
-  "`\\p{gc=Combining_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Combining_Mark}+$/u,
+  matchSymbols,
+  "\\p{gc=Combining_Mark}"
 );
-assert(
-  /^\p{Mark}+$/u.test(matchSymbols),
-  "`\\p{Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Mark}+$/u,
+  matchSymbols,
+  "\\p{Mark}"
 );
-assert(
-  /^\p{M}+$/u.test(matchSymbols),
-  "`\\p{M}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{M}+$/u,
+  matchSymbols,
+  "\\p{M}"
 );
-assert(
-  /^\p{Combining_Mark}+$/u.test(matchSymbols),
-  "`\\p{Combining_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Combining_Mark}+$/u,
+  matchSymbols,
+  "\\p{Combining_Mark}"
 );
 
 const nonMatchSymbols = buildString({
@@ -565,39 +574,48 @@ const nonMatchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Mark}"
 );
-assert(
-  /^\P{General_Category=M}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=M}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=M}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=M}"
 );
-assert(
-  /^\P{General_Category=Combining_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Combining_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Combining_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Combining_Mark}"
 );
-assert(
-  /^\P{gc=Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Mark}"
 );
-assert(
-  /^\P{gc=M}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=M}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=M}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=M}"
 );
-assert(
-  /^\P{gc=Combining_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Combining_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Combining_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Combining_Mark}"
 );
-assert(
-  /^\P{Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{Mark}"
 );
-assert(
-  /^\P{M}+$/u.test(nonMatchSymbols),
-  "`\\P{M}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{M}+$/u,
+  nonMatchSymbols,
+  "\\P{M}"
 );
-assert(
-  /^\P{Combining_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{Combining_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Combining_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{Combining_Mark}"
 );

--- a/output/General_Category_-_Math_Symbol.js
+++ b/output/General_Category_-_Math_Symbol.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -83,29 +83,35 @@ const matchSymbols = buildString({
     [0x01EEF0, 0x01EEF1]
   ]
 });
-assert(
-  /^\p{General_Category=Math_Symbol}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Math_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Math_Symbol}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Math_Symbol}"
 );
-assert(
-  /^\p{General_Category=Sm}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Sm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Sm}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Sm}"
 );
-assert(
-  /^\p{gc=Math_Symbol}+$/u.test(matchSymbols),
-  "`\\p{gc=Math_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Math_Symbol}+$/u,
+  matchSymbols,
+  "\\p{gc=Math_Symbol}"
 );
-assert(
-  /^\p{gc=Sm}+$/u.test(matchSymbols),
-  "`\\p{gc=Sm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Sm}+$/u,
+  matchSymbols,
+  "\\p{gc=Sm}"
 );
-assert(
-  /^\p{Math_Symbol}+$/u.test(matchSymbols),
-  "`\\p{Math_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Math_Symbol}+$/u,
+  matchSymbols,
+  "\\p{Math_Symbol}"
 );
-assert(
-  /^\p{Sm}+$/u.test(matchSymbols),
-  "`\\p{Sm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Sm}+$/u,
+  matchSymbols,
+  "\\p{Sm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -181,27 +187,33 @@ const nonMatchSymbols = buildString({
     [0x01EEF2, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Math_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Math_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Math_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Math_Symbol}"
 );
-assert(
-  /^\P{General_Category=Sm}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Sm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Sm}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Sm}"
 );
-assert(
-  /^\P{gc=Math_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Math_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Math_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Math_Symbol}"
 );
-assert(
-  /^\P{gc=Sm}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Sm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Sm}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Sm}"
 );
-assert(
-  /^\P{Math_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{Math_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Math_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{Math_Symbol}"
 );
-assert(
-  /^\P{Sm}+$/u.test(nonMatchSymbols),
-  "`\\P{Sm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Sm}+$/u,
+  nonMatchSymbols,
+  "\\P{Sm}"
 );

--- a/output/General_Category_-_Modifier_Letter.js
+++ b/output/General_Category_-_Modifier_Letter.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -76,29 +76,35 @@ const matchSymbols = buildString({
     [0x016F93, 0x016F9F]
   ]
 });
-assert(
-  /^\p{General_Category=Modifier_Letter}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Modifier_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Modifier_Letter}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Modifier_Letter}"
 );
-assert(
-  /^\p{General_Category=Lm}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Lm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Lm}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Lm}"
 );
-assert(
-  /^\p{gc=Modifier_Letter}+$/u.test(matchSymbols),
-  "`\\p{gc=Modifier_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Modifier_Letter}+$/u,
+  matchSymbols,
+  "\\p{gc=Modifier_Letter}"
 );
-assert(
-  /^\p{gc=Lm}+$/u.test(matchSymbols),
-  "`\\p{gc=Lm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Lm}+$/u,
+  matchSymbols,
+  "\\p{gc=Lm}"
 );
-assert(
-  /^\p{Modifier_Letter}+$/u.test(matchSymbols),
-  "`\\p{Modifier_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Modifier_Letter}+$/u,
+  matchSymbols,
+  "\\p{Modifier_Letter}"
 );
-assert(
-  /^\p{Lm}+$/u.test(matchSymbols),
-  "`\\p{Lm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Lm}+$/u,
+  matchSymbols,
+  "\\p{Lm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -167,27 +173,33 @@ const nonMatchSymbols = buildString({
     [0x016FE1, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Modifier_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Modifier_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Modifier_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Modifier_Letter}"
 );
-assert(
-  /^\P{General_Category=Lm}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Lm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Lm}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Lm}"
 );
-assert(
-  /^\P{gc=Modifier_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Modifier_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Modifier_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Modifier_Letter}"
 );
-assert(
-  /^\P{gc=Lm}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Lm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Lm}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Lm}"
 );
-assert(
-  /^\P{Modifier_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{Modifier_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Modifier_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{Modifier_Letter}"
 );
-assert(
-  /^\P{Lm}+$/u.test(nonMatchSymbols),
-  "`\\P{Lm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Lm}+$/u,
+  nonMatchSymbols,
+  "\\P{Lm}"
 );

--- a/output/General_Category_-_Modifier_Symbol.js
+++ b/output/General_Category_-_Modifier_Symbol.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -48,29 +48,35 @@ const matchSymbols = buildString({
     [0x01F3FB, 0x01F3FF]
   ]
 });
-assert(
-  /^\p{General_Category=Modifier_Symbol}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Modifier_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Modifier_Symbol}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Modifier_Symbol}"
 );
-assert(
-  /^\p{General_Category=Sk}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Sk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Sk}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Sk}"
 );
-assert(
-  /^\p{gc=Modifier_Symbol}+$/u.test(matchSymbols),
-  "`\\p{gc=Modifier_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Modifier_Symbol}+$/u,
+  matchSymbols,
+  "\\p{gc=Modifier_Symbol}"
 );
-assert(
-  /^\p{gc=Sk}+$/u.test(matchSymbols),
-  "`\\p{gc=Sk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Sk}+$/u,
+  matchSymbols,
+  "\\p{gc=Sk}"
 );
-assert(
-  /^\p{Modifier_Symbol}+$/u.test(matchSymbols),
-  "`\\p{Modifier_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Modifier_Symbol}+$/u,
+  matchSymbols,
+  "\\p{Modifier_Symbol}"
 );
-assert(
-  /^\p{Sk}+$/u.test(matchSymbols),
-  "`\\p{Sk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Sk}+$/u,
+  matchSymbols,
+  "\\p{Sk}"
 );
 
 const nonMatchSymbols = buildString({
@@ -111,27 +117,33 @@ const nonMatchSymbols = buildString({
     [0x01F400, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Modifier_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Modifier_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Modifier_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Modifier_Symbol}"
 );
-assert(
-  /^\P{General_Category=Sk}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Sk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Sk}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Sk}"
 );
-assert(
-  /^\P{gc=Modifier_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Modifier_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Modifier_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Modifier_Symbol}"
 );
-assert(
-  /^\P{gc=Sk}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Sk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Sk}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Sk}"
 );
-assert(
-  /^\P{Modifier_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{Modifier_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Modifier_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{Modifier_Symbol}"
 );
-assert(
-  /^\P{Sk}+$/u.test(nonMatchSymbols),
-  "`\\P{Sk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Sk}+$/u,
+  nonMatchSymbols,
+  "\\P{Sk}"
 );

--- a/output/General_Category_-_Nonspacing_Mark.js
+++ b/output/General_Category_-_Nonspacing_Mark.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -304,29 +304,35 @@ const matchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\p{General_Category=Nonspacing_Mark}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Nonspacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Nonspacing_Mark}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Nonspacing_Mark}"
 );
-assert(
-  /^\p{General_Category=Mn}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Mn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Mn}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Mn}"
 );
-assert(
-  /^\p{gc=Nonspacing_Mark}+$/u.test(matchSymbols),
-  "`\\p{gc=Nonspacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Nonspacing_Mark}+$/u,
+  matchSymbols,
+  "\\p{gc=Nonspacing_Mark}"
 );
-assert(
-  /^\p{gc=Mn}+$/u.test(matchSymbols),
-  "`\\p{gc=Mn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Mn}+$/u,
+  matchSymbols,
+  "\\p{gc=Mn}"
 );
-assert(
-  /^\p{Nonspacing_Mark}+$/u.test(matchSymbols),
-  "`\\p{Nonspacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Nonspacing_Mark}+$/u,
+  matchSymbols,
+  "\\p{Nonspacing_Mark}"
 );
-assert(
-  /^\p{Mn}+$/u.test(matchSymbols),
-  "`\\p{Mn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Mn}+$/u,
+  matchSymbols,
+  "\\p{Mn}"
 );
 
 const nonMatchSymbols = buildString({
@@ -623,27 +629,33 @@ const nonMatchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Nonspacing_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Nonspacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Nonspacing_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Nonspacing_Mark}"
 );
-assert(
-  /^\P{General_Category=Mn}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Mn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Mn}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Mn}"
 );
-assert(
-  /^\P{gc=Nonspacing_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Nonspacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Nonspacing_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Nonspacing_Mark}"
 );
-assert(
-  /^\P{gc=Mn}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Mn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Mn}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Mn}"
 );
-assert(
-  /^\P{Nonspacing_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{Nonspacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Nonspacing_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{Nonspacing_Mark}"
 );
-assert(
-  /^\P{Mn}+$/u.test(nonMatchSymbols),
-  "`\\P{Mn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Mn}+$/u,
+  nonMatchSymbols,
+  "\\P{Mn}"
 );

--- a/output/General_Category_-_Number.js
+++ b/output/General_Category_-_Number.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -134,29 +134,35 @@ const matchSymbols = buildString({
     [0x01F100, 0x01F10C]
   ]
 });
-assert(
-  /^\p{General_Category=Number}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Number}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Number}"
 );
-assert(
-  /^\p{General_Category=N}+$/u.test(matchSymbols),
-  "`\\p{General_Category=N}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=N}+$/u,
+  matchSymbols,
+  "\\p{General_Category=N}"
 );
-assert(
-  /^\p{gc=Number}+$/u.test(matchSymbols),
-  "`\\p{gc=Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Number}+$/u,
+  matchSymbols,
+  "\\p{gc=Number}"
 );
-assert(
-  /^\p{gc=N}+$/u.test(matchSymbols),
-  "`\\p{gc=N}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=N}+$/u,
+  matchSymbols,
+  "\\p{gc=N}"
 );
-assert(
-  /^\p{Number}+$/u.test(matchSymbols),
-  "`\\p{Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Number}+$/u,
+  matchSymbols,
+  "\\p{Number}"
 );
-assert(
-  /^\p{N}+$/u.test(matchSymbols),
-  "`\\p{N}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{N}+$/u,
+  matchSymbols,
+  "\\p{N}"
 );
 
 const nonMatchSymbols = buildString({
@@ -283,27 +289,33 @@ const nonMatchSymbols = buildString({
     [0x01F10D, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Number}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Number}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Number}"
 );
-assert(
-  /^\P{General_Category=N}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=N}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=N}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=N}"
 );
-assert(
-  /^\P{gc=Number}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Number}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Number}"
 );
-assert(
-  /^\P{gc=N}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=N}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=N}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=N}"
 );
-assert(
-  /^\P{Number}+$/u.test(nonMatchSymbols),
-  "`\\P{Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Number}+$/u,
+  nonMatchSymbols,
+  "\\P{Number}"
 );
-assert(
-  /^\P{N}+$/u.test(nonMatchSymbols),
-  "`\\P{N}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{N}+$/u,
+  nonMatchSymbols,
+  "\\P{N}"
 );

--- a/output/General_Category_-_Open_Punctuation.js
+++ b/output/General_Category_-_Open_Punctuation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -93,29 +93,35 @@ const matchSymbols = buildString({
   ],
   ranges: []
 });
-assert(
-  /^\p{General_Category=Open_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Open_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Open_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Open_Punctuation}"
 );
-assert(
-  /^\p{General_Category=Ps}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Ps}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Ps}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Ps}"
 );
-assert(
-  /^\p{gc=Open_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{gc=Open_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Open_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{gc=Open_Punctuation}"
 );
-assert(
-  /^\p{gc=Ps}+$/u.test(matchSymbols),
-  "`\\p{gc=Ps}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Ps}+$/u,
+  matchSymbols,
+  "\\p{gc=Ps}"
 );
-assert(
-  /^\p{Open_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{Open_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Open_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{Open_Punctuation}"
 );
-assert(
-  /^\p{Ps}+$/u.test(matchSymbols),
-  "`\\p{Ps}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Ps}+$/u,
+  matchSymbols,
+  "\\p{Ps}"
 );
 
 const nonMatchSymbols = buildString({
@@ -202,27 +208,33 @@ const nonMatchSymbols = buildString({
     [0x00FF63, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Open_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Open_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Open_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Open_Punctuation}"
 );
-assert(
-  /^\P{General_Category=Ps}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Ps}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Ps}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Ps}"
 );
-assert(
-  /^\P{gc=Open_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Open_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Open_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Open_Punctuation}"
 );
-assert(
-  /^\P{gc=Ps}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Ps}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Ps}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Ps}"
 );
-assert(
-  /^\P{Open_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{Open_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Open_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{Open_Punctuation}"
 );
-assert(
-  /^\P{Ps}+$/u.test(nonMatchSymbols),
-  "`\\P{Ps}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Ps}+$/u,
+  nonMatchSymbols,
+  "\\P{Ps}"
 );

--- a/output/General_Category_-_Other.js
+++ b/output/General_Category_-_Other.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -663,29 +663,35 @@ const matchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\p{General_Category=Other}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Other}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Other}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Other}"
 );
-assert(
-  /^\p{General_Category=C}+$/u.test(matchSymbols),
-  "`\\p{General_Category=C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=C}+$/u,
+  matchSymbols,
+  "\\p{General_Category=C}"
 );
-assert(
-  /^\p{gc=Other}+$/u.test(matchSymbols),
-  "`\\p{gc=Other}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Other}+$/u,
+  matchSymbols,
+  "\\p{gc=Other}"
 );
-assert(
-  /^\p{gc=C}+$/u.test(matchSymbols),
-  "`\\p{gc=C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=C}+$/u,
+  matchSymbols,
+  "\\p{gc=C}"
 );
-assert(
-  /^\p{Other}+$/u.test(matchSymbols),
-  "`\\p{Other}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Other}+$/u,
+  matchSymbols,
+  "\\p{Other}"
 );
-assert(
-  /^\p{C}+$/u.test(matchSymbols),
-  "`\\p{C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{C}+$/u,
+  matchSymbols,
+  "\\p{C}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1336,27 +1342,33 @@ const nonMatchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\P{General_Category=Other}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Other}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Other}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Other}"
 );
-assert(
-  /^\P{General_Category=C}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=C}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=C}"
 );
-assert(
-  /^\P{gc=Other}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Other}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Other}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Other}"
 );
-assert(
-  /^\P{gc=C}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=C}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=C}"
 );
-assert(
-  /^\P{Other}+$/u.test(nonMatchSymbols),
-  "`\\P{Other}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Other}+$/u,
+  nonMatchSymbols,
+  "\\P{Other}"
 );
-assert(
-  /^\P{C}+$/u.test(nonMatchSymbols),
-  "`\\P{C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{C}+$/u,
+  nonMatchSymbols,
+  "\\P{C}"
 );

--- a/output/General_Category_-_Other_Letter.js
+++ b/output/General_Category_-_Other_Letter.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -464,29 +464,35 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{General_Category=Other_Letter}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Other_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Other_Letter}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Other_Letter}"
 );
-assert(
-  /^\p{General_Category=Lo}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Lo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Lo}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Lo}"
 );
-assert(
-  /^\p{gc=Other_Letter}+$/u.test(matchSymbols),
-  "`\\p{gc=Other_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Other_Letter}+$/u,
+  matchSymbols,
+  "\\p{gc=Other_Letter}"
 );
-assert(
-  /^\p{gc=Lo}+$/u.test(matchSymbols),
-  "`\\p{gc=Lo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Lo}+$/u,
+  matchSymbols,
+  "\\p{gc=Lo}"
 );
-assert(
-  /^\p{Other_Letter}+$/u.test(matchSymbols),
-  "`\\p{Other_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Other_Letter}+$/u,
+  matchSymbols,
+  "\\p{Other_Letter}"
 );
-assert(
-  /^\p{Lo}+$/u.test(matchSymbols),
-  "`\\p{Lo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Lo}+$/u,
+  matchSymbols,
+  "\\p{Lo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -943,27 +949,33 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Other_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Other_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Other_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Other_Letter}"
 );
-assert(
-  /^\P{General_Category=Lo}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Lo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Lo}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Lo}"
 );
-assert(
-  /^\P{gc=Other_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Other_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Other_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Other_Letter}"
 );
-assert(
-  /^\P{gc=Lo}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Lo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Lo}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Lo}"
 );
-assert(
-  /^\P{Other_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{Other_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Other_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{Other_Letter}"
 );
-assert(
-  /^\P{Lo}+$/u.test(nonMatchSymbols),
-  "`\\P{Lo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Lo}+$/u,
+  nonMatchSymbols,
+  "\\P{Lo}"
 );

--- a/output/General_Category_-_Other_Number.js
+++ b/output/General_Category_-_Other_Number.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -79,29 +79,35 @@ const matchSymbols = buildString({
     [0x01F100, 0x01F10C]
   ]
 });
-assert(
-  /^\p{General_Category=Other_Number}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Other_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Other_Number}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Other_Number}"
 );
-assert(
-  /^\p{General_Category=No}+$/u.test(matchSymbols),
-  "`\\p{General_Category=No}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=No}+$/u,
+  matchSymbols,
+  "\\p{General_Category=No}"
 );
-assert(
-  /^\p{gc=Other_Number}+$/u.test(matchSymbols),
-  "`\\p{gc=Other_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Other_Number}+$/u,
+  matchSymbols,
+  "\\p{gc=Other_Number}"
 );
-assert(
-  /^\p{gc=No}+$/u.test(matchSymbols),
-  "`\\p{gc=No}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=No}+$/u,
+  matchSymbols,
+  "\\p{gc=No}"
 );
-assert(
-  /^\p{Other_Number}+$/u.test(matchSymbols),
-  "`\\p{Other_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Other_Number}+$/u,
+  matchSymbols,
+  "\\p{Other_Number}"
 );
-assert(
-  /^\p{No}+$/u.test(matchSymbols),
-  "`\\p{No}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{No}+$/u,
+  matchSymbols,
+  "\\p{No}"
 );
 
 const nonMatchSymbols = buildString({
@@ -173,27 +179,33 @@ const nonMatchSymbols = buildString({
     [0x01F10D, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Other_Number}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Other_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Other_Number}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Other_Number}"
 );
-assert(
-  /^\P{General_Category=No}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=No}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=No}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=No}"
 );
-assert(
-  /^\P{gc=Other_Number}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Other_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Other_Number}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Other_Number}"
 );
-assert(
-  /^\P{gc=No}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=No}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=No}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=No}"
 );
-assert(
-  /^\P{Other_Number}+$/u.test(nonMatchSymbols),
-  "`\\P{Other_Number}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Other_Number}+$/u,
+  nonMatchSymbols,
+  "\\P{Other_Number}"
 );
-assert(
-  /^\P{No}+$/u.test(nonMatchSymbols),
-  "`\\P{No}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{No}+$/u,
+  nonMatchSymbols,
+  "\\P{No}"
 );

--- a/output/General_Category_-_Other_Punctuation.js
+++ b/output/General_Category_-_Other_Punctuation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -184,29 +184,35 @@ const matchSymbols = buildString({
     [0x01E95E, 0x01E95F]
   ]
 });
-assert(
-  /^\p{General_Category=Other_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Other_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Other_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Other_Punctuation}"
 );
-assert(
-  /^\p{General_Category=Po}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Po}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Po}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Po}"
 );
-assert(
-  /^\p{gc=Other_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{gc=Other_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Other_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{gc=Other_Punctuation}"
 );
-assert(
-  /^\p{gc=Po}+$/u.test(matchSymbols),
-  "`\\p{gc=Po}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Po}+$/u,
+  matchSymbols,
+  "\\p{gc=Po}"
 );
-assert(
-  /^\p{Other_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{Other_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Other_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{Other_Punctuation}"
 );
-assert(
-  /^\p{Po}+$/u.test(matchSymbols),
-  "`\\p{Po}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Po}+$/u,
+  matchSymbols,
+  "\\p{Po}"
 );
 
 const nonMatchSymbols = buildString({
@@ -383,27 +389,33 @@ const nonMatchSymbols = buildString({
     [0x01E960, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Other_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Other_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Other_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Other_Punctuation}"
 );
-assert(
-  /^\P{General_Category=Po}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Po}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Po}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Po}"
 );
-assert(
-  /^\P{gc=Other_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Other_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Other_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Other_Punctuation}"
 );
-assert(
-  /^\P{gc=Po}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Po}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Po}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Po}"
 );
-assert(
-  /^\P{Other_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{Other_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Other_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{Other_Punctuation}"
 );
-assert(
-  /^\P{Po}+$/u.test(nonMatchSymbols),
-  "`\\P{Po}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Po}+$/u,
+  nonMatchSymbols,
+  "\\P{Po}"
 );

--- a/output/General_Category_-_Other_Symbol.js
+++ b/output/General_Category_-_Other_Symbol.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -193,29 +193,35 @@ const matchSymbols = buildString({
     [0x01F980, 0x01F991]
   ]
 });
-assert(
-  /^\p{General_Category=Other_Symbol}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Other_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Other_Symbol}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Other_Symbol}"
 );
-assert(
-  /^\p{General_Category=So}+$/u.test(matchSymbols),
-  "`\\p{General_Category=So}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=So}+$/u,
+  matchSymbols,
+  "\\p{General_Category=So}"
 );
-assert(
-  /^\p{gc=Other_Symbol}+$/u.test(matchSymbols),
-  "`\\p{gc=Other_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Other_Symbol}+$/u,
+  matchSymbols,
+  "\\p{gc=Other_Symbol}"
 );
-assert(
-  /^\p{gc=So}+$/u.test(matchSymbols),
-  "`\\p{gc=So}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=So}+$/u,
+  matchSymbols,
+  "\\p{gc=So}"
 );
-assert(
-  /^\p{Other_Symbol}+$/u.test(matchSymbols),
-  "`\\p{Other_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Other_Symbol}+$/u,
+  matchSymbols,
+  "\\p{Other_Symbol}"
 );
-assert(
-  /^\p{So}+$/u.test(matchSymbols),
-  "`\\p{So}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{So}+$/u,
+  matchSymbols,
+  "\\p{So}"
 );
 
 const nonMatchSymbols = buildString({
@@ -401,27 +407,33 @@ const nonMatchSymbols = buildString({
     [0x01F9C1, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Other_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Other_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Other_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Other_Symbol}"
 );
-assert(
-  /^\P{General_Category=So}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=So}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=So}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=So}"
 );
-assert(
-  /^\P{gc=Other_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Other_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Other_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Other_Symbol}"
 );
-assert(
-  /^\P{gc=So}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=So}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=So}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=So}"
 );
-assert(
-  /^\P{Other_Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{Other_Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Other_Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{Other_Symbol}"
 );
-assert(
-  /^\P{So}+$/u.test(nonMatchSymbols),
-  "`\\P{So}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{So}+$/u,
+  nonMatchSymbols,
+  "\\P{So}"
 );

--- a/output/General_Category_-_Paragraph_Separator.js
+++ b/output/General_Category_-_Paragraph_Separator.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,29 +19,35 @@ const matchSymbols = buildString({
   ],
   ranges: []
 });
-assert(
-  /^\p{General_Category=Paragraph_Separator}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Paragraph_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Paragraph_Separator}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Paragraph_Separator}"
 );
-assert(
-  /^\p{General_Category=Zp}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Zp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Zp}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Zp}"
 );
-assert(
-  /^\p{gc=Paragraph_Separator}+$/u.test(matchSymbols),
-  "`\\p{gc=Paragraph_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Paragraph_Separator}+$/u,
+  matchSymbols,
+  "\\p{gc=Paragraph_Separator}"
 );
-assert(
-  /^\p{gc=Zp}+$/u.test(matchSymbols),
-  "`\\p{gc=Zp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Zp}+$/u,
+  matchSymbols,
+  "\\p{gc=Zp}"
 );
-assert(
-  /^\p{Paragraph_Separator}+$/u.test(matchSymbols),
-  "`\\p{Paragraph_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Paragraph_Separator}+$/u,
+  matchSymbols,
+  "\\p{Paragraph_Separator}"
 );
-assert(
-  /^\p{Zp}+$/u.test(matchSymbols),
-  "`\\p{Zp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Zp}+$/u,
+  matchSymbols,
+  "\\p{Zp}"
 );
 
 const nonMatchSymbols = buildString({
@@ -53,27 +59,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Paragraph_Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Paragraph_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Paragraph_Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Paragraph_Separator}"
 );
-assert(
-  /^\P{General_Category=Zp}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Zp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Zp}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Zp}"
 );
-assert(
-  /^\P{gc=Paragraph_Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Paragraph_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Paragraph_Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Paragraph_Separator}"
 );
-assert(
-  /^\P{gc=Zp}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Zp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Zp}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Zp}"
 );
-assert(
-  /^\P{Paragraph_Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{Paragraph_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Paragraph_Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{Paragraph_Separator}"
 );
-assert(
-  /^\P{Zp}+$/u.test(nonMatchSymbols),
-  "`\\P{Zp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Zp}+$/u,
+  nonMatchSymbols,
+  "\\P{Zp}"
 );

--- a/output/General_Category_-_Private_Use.js
+++ b/output/General_Category_-_Private_Use.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,29 +21,35 @@ const matchSymbols = buildString({
     [0x100000, 0x10FFFD]
   ]
 });
-assert(
-  /^\p{General_Category=Private_Use}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Private_Use}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Private_Use}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Private_Use}"
 );
-assert(
-  /^\p{General_Category=Co}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Co}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Co}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Co}"
 );
-assert(
-  /^\p{gc=Private_Use}+$/u.test(matchSymbols),
-  "`\\p{gc=Private_Use}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Private_Use}+$/u,
+  matchSymbols,
+  "\\p{gc=Private_Use}"
 );
-assert(
-  /^\p{gc=Co}+$/u.test(matchSymbols),
-  "`\\p{gc=Co}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Co}+$/u,
+  matchSymbols,
+  "\\p{gc=Co}"
 );
-assert(
-  /^\p{Private_Use}+$/u.test(matchSymbols),
-  "`\\p{Private_Use}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Private_Use}+$/u,
+  matchSymbols,
+  "\\p{Private_Use}"
 );
-assert(
-  /^\p{Co}+$/u.test(matchSymbols),
-  "`\\p{Co}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Co}+$/u,
+  matchSymbols,
+  "\\p{Co}"
 );
 
 const nonMatchSymbols = buildString({
@@ -56,27 +62,33 @@ const nonMatchSymbols = buildString({
     [0x10FFFE, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Private_Use}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Private_Use}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Private_Use}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Private_Use}"
 );
-assert(
-  /^\P{General_Category=Co}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Co}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Co}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Co}"
 );
-assert(
-  /^\P{gc=Private_Use}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Private_Use}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Private_Use}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Private_Use}"
 );
-assert(
-  /^\P{gc=Co}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Co}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Co}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Co}"
 );
-assert(
-  /^\P{Private_Use}+$/u.test(nonMatchSymbols),
-  "`\\P{Private_Use}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Private_Use}+$/u,
+  nonMatchSymbols,
+  "\\P{Private_Use}"
 );
-assert(
-  /^\P{Co}+$/u.test(nonMatchSymbols),
-  "`\\P{Co}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Co}+$/u,
+  nonMatchSymbols,
+  "\\P{Co}"
 );

--- a/output/General_Category_-_Punctuation.js
+++ b/output/General_Category_-_Punctuation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -187,41 +187,50 @@ const matchSymbols = buildString({
     [0x01E95E, 0x01E95F]
   ]
 });
-assert(
-  /^\p{General_Category=Punctuation}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Punctuation}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Punctuation}"
 );
-assert(
-  /^\p{General_Category=P}+$/u.test(matchSymbols),
-  "`\\p{General_Category=P}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=P}+$/u,
+  matchSymbols,
+  "\\p{General_Category=P}"
 );
-assert(
-  /^\p{General_Category=punct}+$/u.test(matchSymbols),
-  "`\\p{General_Category=punct}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=punct}+$/u,
+  matchSymbols,
+  "\\p{General_Category=punct}"
 );
-assert(
-  /^\p{gc=Punctuation}+$/u.test(matchSymbols),
-  "`\\p{gc=Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Punctuation}+$/u,
+  matchSymbols,
+  "\\p{gc=Punctuation}"
 );
-assert(
-  /^\p{gc=P}+$/u.test(matchSymbols),
-  "`\\p{gc=P}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=P}+$/u,
+  matchSymbols,
+  "\\p{gc=P}"
 );
-assert(
-  /^\p{gc=punct}+$/u.test(matchSymbols),
-  "`\\p{gc=punct}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=punct}+$/u,
+  matchSymbols,
+  "\\p{gc=punct}"
 );
-assert(
-  /^\p{Punctuation}+$/u.test(matchSymbols),
-  "`\\p{Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Punctuation}+$/u,
+  matchSymbols,
+  "\\p{Punctuation}"
 );
-assert(
-  /^\p{P}+$/u.test(matchSymbols),
-  "`\\p{P}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{P}+$/u,
+  matchSymbols,
+  "\\p{P}"
 );
-assert(
-  /^\p{punct}+$/u.test(matchSymbols),
-  "`\\p{punct}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{punct}+$/u,
+  matchSymbols,
+  "\\p{punct}"
 );
 
 const nonMatchSymbols = buildString({
@@ -401,39 +410,48 @@ const nonMatchSymbols = buildString({
     [0x01E960, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Punctuation}"
 );
-assert(
-  /^\P{General_Category=P}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=P}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=P}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=P}"
 );
-assert(
-  /^\P{General_Category=punct}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=punct}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=punct}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=punct}"
 );
-assert(
-  /^\P{gc=Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Punctuation}"
 );
-assert(
-  /^\P{gc=P}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=P}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=P}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=P}"
 );
-assert(
-  /^\P{gc=punct}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=punct}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=punct}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=punct}"
 );
-assert(
-  /^\P{Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{Punctuation}"
 );
-assert(
-  /^\P{P}+$/u.test(nonMatchSymbols),
-  "`\\P{P}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{P}+$/u,
+  nonMatchSymbols,
+  "\\P{P}"
 );
-assert(
-  /^\P{punct}+$/u.test(nonMatchSymbols),
-  "`\\P{punct}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{punct}+$/u,
+  nonMatchSymbols,
+  "\\P{punct}"
 );

--- a/output/General_Category_-_Separator.js
+++ b/output/General_Category_-_Separator.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -27,29 +27,35 @@ const matchSymbols = buildString({
     [0x002028, 0x002029]
   ]
 });
-assert(
-  /^\p{General_Category=Separator}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Separator}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Separator}"
 );
-assert(
-  /^\p{General_Category=Z}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Z}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Z}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Z}"
 );
-assert(
-  /^\p{gc=Separator}+$/u.test(matchSymbols),
-  "`\\p{gc=Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Separator}+$/u,
+  matchSymbols,
+  "\\p{gc=Separator}"
 );
-assert(
-  /^\p{gc=Z}+$/u.test(matchSymbols),
-  "`\\p{gc=Z}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Z}+$/u,
+  matchSymbols,
+  "\\p{gc=Z}"
 );
-assert(
-  /^\p{Separator}+$/u.test(matchSymbols),
-  "`\\p{Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Separator}+$/u,
+  matchSymbols,
+  "\\p{Separator}"
 );
-assert(
-  /^\p{Z}+$/u.test(matchSymbols),
-  "`\\p{Z}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Z}+$/u,
+  matchSymbols,
+  "\\p{Z}"
 );
 
 const nonMatchSymbols = buildString({
@@ -68,27 +74,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Separator}"
 );
-assert(
-  /^\P{General_Category=Z}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Z}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Z}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Z}"
 );
-assert(
-  /^\P{gc=Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Separator}"
 );
-assert(
-  /^\P{gc=Z}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Z}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Z}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Z}"
 );
-assert(
-  /^\P{Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{Separator}"
 );
-assert(
-  /^\P{Z}+$/u.test(nonMatchSymbols),
-  "`\\P{Z}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Z}+$/u,
+  nonMatchSymbols,
+  "\\P{Z}"
 );

--- a/output/General_Category_-_Space_Separator.js
+++ b/output/General_Category_-_Space_Separator.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -26,29 +26,35 @@ const matchSymbols = buildString({
     [0x002000, 0x00200A]
   ]
 });
-assert(
-  /^\p{General_Category=Space_Separator}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Space_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Space_Separator}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Space_Separator}"
 );
-assert(
-  /^\p{General_Category=Zs}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Zs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Zs}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Zs}"
 );
-assert(
-  /^\p{gc=Space_Separator}+$/u.test(matchSymbols),
-  "`\\p{gc=Space_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Space_Separator}+$/u,
+  matchSymbols,
+  "\\p{gc=Space_Separator}"
 );
-assert(
-  /^\p{gc=Zs}+$/u.test(matchSymbols),
-  "`\\p{gc=Zs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Zs}+$/u,
+  matchSymbols,
+  "\\p{gc=Zs}"
 );
-assert(
-  /^\p{Space_Separator}+$/u.test(matchSymbols),
-  "`\\p{Space_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Space_Separator}+$/u,
+  matchSymbols,
+  "\\p{Space_Separator}"
 );
-assert(
-  /^\p{Zs}+$/u.test(matchSymbols),
-  "`\\p{Zs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Zs}+$/u,
+  matchSymbols,
+  "\\p{Zs}"
 );
 
 const nonMatchSymbols = buildString({
@@ -66,27 +72,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Space_Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Space_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Space_Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Space_Separator}"
 );
-assert(
-  /^\P{General_Category=Zs}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Zs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Zs}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Zs}"
 );
-assert(
-  /^\P{gc=Space_Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Space_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Space_Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Space_Separator}"
 );
-assert(
-  /^\P{gc=Zs}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Zs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Zs}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Zs}"
 );
-assert(
-  /^\P{Space_Separator}+$/u.test(nonMatchSymbols),
-  "`\\P{Space_Separator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Space_Separator}+$/u,
+  nonMatchSymbols,
+  "\\P{Space_Separator}"
 );
-assert(
-  /^\P{Zs}+$/u.test(nonMatchSymbols),
-  "`\\P{Zs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Zs}+$/u,
+  nonMatchSymbols,
+  "\\P{Zs}"
 );

--- a/output/General_Category_-_Spacing_Mark.js
+++ b/output/General_Category_-_Spacing_Mark.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -174,29 +174,35 @@ const matchSymbols = buildString({
     [0x01D16D, 0x01D172]
   ]
 });
-assert(
-  /^\p{General_Category=Spacing_Mark}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Spacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Spacing_Mark}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Spacing_Mark}"
 );
-assert(
-  /^\p{General_Category=Mc}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Mc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Mc}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Mc}"
 );
-assert(
-  /^\p{gc=Spacing_Mark}+$/u.test(matchSymbols),
-  "`\\p{gc=Spacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Spacing_Mark}+$/u,
+  matchSymbols,
+  "\\p{gc=Spacing_Mark}"
 );
-assert(
-  /^\p{gc=Mc}+$/u.test(matchSymbols),
-  "`\\p{gc=Mc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Mc}+$/u,
+  matchSymbols,
+  "\\p{gc=Mc}"
 );
-assert(
-  /^\p{Spacing_Mark}+$/u.test(matchSymbols),
-  "`\\p{Spacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Spacing_Mark}+$/u,
+  matchSymbols,
+  "\\p{Spacing_Mark}"
 );
-assert(
-  /^\p{Mc}+$/u.test(matchSymbols),
-  "`\\p{Mc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Mc}+$/u,
+  matchSymbols,
+  "\\p{Mc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -363,27 +369,33 @@ const nonMatchSymbols = buildString({
     [0x01D173, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Spacing_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Spacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Spacing_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Spacing_Mark}"
 );
-assert(
-  /^\P{General_Category=Mc}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Mc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Mc}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Mc}"
 );
-assert(
-  /^\P{gc=Spacing_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Spacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Spacing_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Spacing_Mark}"
 );
-assert(
-  /^\P{gc=Mc}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Mc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Mc}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Mc}"
 );
-assert(
-  /^\P{Spacing_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{Spacing_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Spacing_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{Spacing_Mark}"
 );
-assert(
-  /^\P{Mc}+$/u.test(nonMatchSymbols),
-  "`\\P{Mc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Mc}+$/u,
+  nonMatchSymbols,
+  "\\P{Mc}"
 );

--- a/output/General_Category_-_Surrogate.js
+++ b/output/General_Category_-_Surrogate.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,29 +20,35 @@ const matchSymbols = buildString({
     [0x00D800, 0x00DBFF]
   ]
 });
-assert(
-  /^\p{General_Category=Surrogate}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Surrogate}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Surrogate}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Surrogate}"
 );
-assert(
-  /^\p{General_Category=Cs}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Cs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Cs}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Cs}"
 );
-assert(
-  /^\p{gc=Surrogate}+$/u.test(matchSymbols),
-  "`\\p{gc=Surrogate}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Surrogate}+$/u,
+  matchSymbols,
+  "\\p{gc=Surrogate}"
 );
-assert(
-  /^\p{gc=Cs}+$/u.test(matchSymbols),
-  "`\\p{gc=Cs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Cs}+$/u,
+  matchSymbols,
+  "\\p{gc=Cs}"
 );
-assert(
-  /^\p{Surrogate}+$/u.test(matchSymbols),
-  "`\\p{Surrogate}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Surrogate}+$/u,
+  matchSymbols,
+  "\\p{Surrogate}"
 );
-assert(
-  /^\p{Cs}+$/u.test(matchSymbols),
-  "`\\p{Cs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Cs}+$/u,
+  matchSymbols,
+  "\\p{Cs}"
 );
 
 const nonMatchSymbols = buildString({
@@ -53,27 +59,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Surrogate}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Surrogate}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Surrogate}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Surrogate}"
 );
-assert(
-  /^\P{General_Category=Cs}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Cs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Cs}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Cs}"
 );
-assert(
-  /^\P{gc=Surrogate}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Surrogate}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Surrogate}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Surrogate}"
 );
-assert(
-  /^\P{gc=Cs}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Cs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Cs}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Cs}"
 );
-assert(
-  /^\P{Surrogate}+$/u.test(nonMatchSymbols),
-  "`\\P{Surrogate}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Surrogate}+$/u,
+  nonMatchSymbols,
+  "\\P{Surrogate}"
 );
-assert(
-  /^\P{Cs}+$/u.test(nonMatchSymbols),
-  "`\\P{Cs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Cs}+$/u,
+  nonMatchSymbols,
+  "\\P{Cs}"
 );

--- a/output/General_Category_-_Symbol.js
+++ b/output/General_Category_-_Symbol.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -237,29 +237,35 @@ const matchSymbols = buildString({
     [0x01F980, 0x01F991]
   ]
 });
-assert(
-  /^\p{General_Category=Symbol}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Symbol}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Symbol}"
 );
-assert(
-  /^\p{General_Category=S}+$/u.test(matchSymbols),
-  "`\\p{General_Category=S}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=S}+$/u,
+  matchSymbols,
+  "\\p{General_Category=S}"
 );
-assert(
-  /^\p{gc=Symbol}+$/u.test(matchSymbols),
-  "`\\p{gc=Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Symbol}+$/u,
+  matchSymbols,
+  "\\p{gc=Symbol}"
 );
-assert(
-  /^\p{gc=S}+$/u.test(matchSymbols),
-  "`\\p{gc=S}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=S}+$/u,
+  matchSymbols,
+  "\\p{gc=S}"
 );
-assert(
-  /^\p{Symbol}+$/u.test(matchSymbols),
-  "`\\p{Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Symbol}+$/u,
+  matchSymbols,
+  "\\p{Symbol}"
 );
-assert(
-  /^\p{S}+$/u.test(matchSymbols),
-  "`\\p{S}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{S}+$/u,
+  matchSymbols,
+  "\\p{S}"
 );
 
 const nonMatchSymbols = buildString({
@@ -489,27 +495,33 @@ const nonMatchSymbols = buildString({
     [0x01F9C1, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Symbol}"
 );
-assert(
-  /^\P{General_Category=S}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=S}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=S}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=S}"
 );
-assert(
-  /^\P{gc=Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Symbol}"
 );
-assert(
-  /^\P{gc=S}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=S}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=S}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=S}"
 );
-assert(
-  /^\P{Symbol}+$/u.test(nonMatchSymbols),
-  "`\\P{Symbol}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Symbol}+$/u,
+  nonMatchSymbols,
+  "\\P{Symbol}"
 );
-assert(
-  /^\P{S}+$/u.test(nonMatchSymbols),
-  "`\\P{S}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{S}+$/u,
+  nonMatchSymbols,
+  "\\P{S}"
 );

--- a/output/General_Category_-_Titlecase_Letter.js
+++ b/output/General_Category_-_Titlecase_Letter.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -29,29 +29,35 @@ const matchSymbols = buildString({
     [0x001FA8, 0x001FAF]
   ]
 });
-assert(
-  /^\p{General_Category=Titlecase_Letter}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Titlecase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Titlecase_Letter}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Titlecase_Letter}"
 );
-assert(
-  /^\p{General_Category=Lt}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Lt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Lt}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Lt}"
 );
-assert(
-  /^\p{gc=Titlecase_Letter}+$/u.test(matchSymbols),
-  "`\\p{gc=Titlecase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Titlecase_Letter}+$/u,
+  matchSymbols,
+  "\\p{gc=Titlecase_Letter}"
 );
-assert(
-  /^\p{gc=Lt}+$/u.test(matchSymbols),
-  "`\\p{gc=Lt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Lt}+$/u,
+  matchSymbols,
+  "\\p{gc=Lt}"
 );
-assert(
-  /^\p{Titlecase_Letter}+$/u.test(matchSymbols),
-  "`\\p{Titlecase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Titlecase_Letter}+$/u,
+  matchSymbols,
+  "\\p{Titlecase_Letter}"
 );
-assert(
-  /^\p{Lt}+$/u.test(matchSymbols),
-  "`\\p{Lt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Lt}+$/u,
+  matchSymbols,
+  "\\p{Lt}"
 );
 
 const nonMatchSymbols = buildString({
@@ -72,27 +78,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Titlecase_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Titlecase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Titlecase_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Titlecase_Letter}"
 );
-assert(
-  /^\P{General_Category=Lt}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Lt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Lt}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Lt}"
 );
-assert(
-  /^\P{gc=Titlecase_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Titlecase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Titlecase_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Titlecase_Letter}"
 );
-assert(
-  /^\P{gc=Lt}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Lt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Lt}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Lt}"
 );
-assert(
-  /^\P{Titlecase_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{Titlecase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Titlecase_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{Titlecase_Letter}"
 );
-assert(
-  /^\P{Lt}+$/u.test(nonMatchSymbols),
-  "`\\P{Lt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Lt}+$/u,
+  nonMatchSymbols,
+  "\\P{Lt}"
 );

--- a/output/General_Category_-_Unassigned.js
+++ b/output/General_Category_-_Unassigned.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -657,29 +657,35 @@ const matchSymbols = buildString({
     [0x10FFFE, 0x10FFFF]
   ]
 });
-assert(
-  /^\p{General_Category=Unassigned}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Unassigned}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Unassigned}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Unassigned}"
 );
-assert(
-  /^\p{General_Category=Cn}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Cn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Cn}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Cn}"
 );
-assert(
-  /^\p{gc=Unassigned}+$/u.test(matchSymbols),
-  "`\\p{gc=Unassigned}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Unassigned}+$/u,
+  matchSymbols,
+  "\\p{gc=Unassigned}"
 );
-assert(
-  /^\p{gc=Cn}+$/u.test(matchSymbols),
-  "`\\p{gc=Cn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Cn}+$/u,
+  matchSymbols,
+  "\\p{gc=Cn}"
 );
-assert(
-  /^\p{Unassigned}+$/u.test(matchSymbols),
-  "`\\p{Unassigned}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Unassigned}+$/u,
+  matchSymbols,
+  "\\p{Unassigned}"
 );
-assert(
-  /^\p{Cn}+$/u.test(matchSymbols),
-  "`\\p{Cn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Cn}+$/u,
+  matchSymbols,
+  "\\p{Cn}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1328,27 +1334,33 @@ const nonMatchSymbols = buildString({
     [0x100000, 0x10FFFD]
   ]
 });
-assert(
-  /^\P{General_Category=Unassigned}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Unassigned}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Unassigned}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Unassigned}"
 );
-assert(
-  /^\P{General_Category=Cn}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Cn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Cn}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Cn}"
 );
-assert(
-  /^\P{gc=Unassigned}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Unassigned}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Unassigned}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Unassigned}"
 );
-assert(
-  /^\P{gc=Cn}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Cn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Cn}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Cn}"
 );
-assert(
-  /^\P{Unassigned}+$/u.test(nonMatchSymbols),
-  "`\\P{Unassigned}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Unassigned}+$/u,
+  nonMatchSymbols,
+  "\\P{Unassigned}"
 );
-assert(
-  /^\P{Cn}+$/u.test(nonMatchSymbols),
-  "`\\P{Cn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Cn}+$/u,
+  nonMatchSymbols,
+  "\\P{Cn}"
 );

--- a/output/General_Category_-_Uppercase_Letter.js
+++ b/output/General_Category_-_Uppercase_Letter.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -646,29 +646,35 @@ const matchSymbols = buildString({
     [0x01E900, 0x01E921]
   ]
 });
-assert(
-  /^\p{General_Category=Uppercase_Letter}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Uppercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Uppercase_Letter}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Uppercase_Letter}"
 );
-assert(
-  /^\p{General_Category=Lu}+$/u.test(matchSymbols),
-  "`\\p{General_Category=Lu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{General_Category=Lu}+$/u,
+  matchSymbols,
+  "\\p{General_Category=Lu}"
 );
-assert(
-  /^\p{gc=Uppercase_Letter}+$/u.test(matchSymbols),
-  "`\\p{gc=Uppercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Uppercase_Letter}+$/u,
+  matchSymbols,
+  "\\p{gc=Uppercase_Letter}"
 );
-assert(
-  /^\p{gc=Lu}+$/u.test(matchSymbols),
-  "`\\p{gc=Lu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{gc=Lu}+$/u,
+  matchSymbols,
+  "\\p{gc=Lu}"
 );
-assert(
-  /^\p{Uppercase_Letter}+$/u.test(matchSymbols),
-  "`\\p{Uppercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Uppercase_Letter}+$/u,
+  matchSymbols,
+  "\\p{Uppercase_Letter}"
 );
-assert(
-  /^\p{Lu}+$/u.test(matchSymbols),
-  "`\\p{Lu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Lu}+$/u,
+  matchSymbols,
+  "\\p{Lu}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1307,27 +1313,33 @@ const nonMatchSymbols = buildString({
     [0x01E922, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{General_Category=Uppercase_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Uppercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Uppercase_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Uppercase_Letter}"
 );
-assert(
-  /^\P{General_Category=Lu}+$/u.test(nonMatchSymbols),
-  "`\\P{General_Category=Lu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{General_Category=Lu}+$/u,
+  nonMatchSymbols,
+  "\\P{General_Category=Lu}"
 );
-assert(
-  /^\P{gc=Uppercase_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Uppercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Uppercase_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Uppercase_Letter}"
 );
-assert(
-  /^\P{gc=Lu}+$/u.test(nonMatchSymbols),
-  "`\\P{gc=Lu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{gc=Lu}+$/u,
+  nonMatchSymbols,
+  "\\P{gc=Lu}"
 );
-assert(
-  /^\P{Uppercase_Letter}+$/u.test(nonMatchSymbols),
-  "`\\P{Uppercase_Letter}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Uppercase_Letter}+$/u,
+  nonMatchSymbols,
+  "\\P{Uppercase_Letter}"
 );
-assert(
-  /^\P{Lu}+$/u.test(nonMatchSymbols),
-  "`\\P{Lu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Lu}+$/u,
+  nonMatchSymbols,
+  "\\P{Lu}"
 );

--- a/output/Grapheme_Base.js
+++ b/output/Grapheme_Base.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -791,13 +791,15 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{Grapheme_Base}+$/u.test(matchSymbols),
-  "`\\p{Grapheme_Base}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Grapheme_Base}+$/u,
+  matchSymbols,
+  "\\p{Grapheme_Base}"
 );
-assert(
-  /^\p{Gr_Base}+$/u.test(matchSymbols),
-  "`\\p{Gr_Base}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Gr_Base}+$/u,
+  matchSymbols,
+  "\\p{Gr_Base}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1581,11 +1583,13 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Grapheme_Base}+$/u.test(nonMatchSymbols),
-  "`\\P{Grapheme_Base}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Grapheme_Base}+$/u,
+  nonMatchSymbols,
+  "\\P{Grapheme_Base}"
 );
-assert(
-  /^\P{Gr_Base}+$/u.test(nonMatchSymbols),
-  "`\\P{Gr_Base}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Gr_Base}+$/u,
+  nonMatchSymbols,
+  "\\P{Gr_Base}"
 );

--- a/output/Grapheme_Extend.js
+++ b/output/Grapheme_Extend.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -322,13 +322,15 @@ const matchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\p{Grapheme_Extend}+$/u.test(matchSymbols),
-  "`\\p{Grapheme_Extend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Grapheme_Extend}+$/u,
+  matchSymbols,
+  "\\p{Grapheme_Extend}"
 );
-assert(
-  /^\p{Gr_Ext}+$/u.test(matchSymbols),
-  "`\\p{Gr_Ext}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Gr_Ext}+$/u,
+  matchSymbols,
+  "\\p{Gr_Ext}"
 );
 
 const nonMatchSymbols = buildString({
@@ -643,11 +645,13 @@ const nonMatchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Grapheme_Extend}+$/u.test(nonMatchSymbols),
-  "`\\P{Grapheme_Extend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Grapheme_Extend}+$/u,
+  nonMatchSymbols,
+  "\\P{Grapheme_Extend}"
 );
-assert(
-  /^\P{Gr_Ext}+$/u.test(nonMatchSymbols),
-  "`\\P{Gr_Ext}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Gr_Ext}+$/u,
+  nonMatchSymbols,
+  "\\P{Gr_Ext}"
 );

--- a/output/Hex_Digit.js
+++ b/output/Hex_Digit.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -24,13 +24,15 @@ const matchSymbols = buildString({
     [0x00FF41, 0x00FF46]
   ]
 });
-assert(
-  /^\p{Hex_Digit}+$/u.test(matchSymbols),
-  "`\\p{Hex_Digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Hex_Digit}+$/u,
+  matchSymbols,
+  "\\p{Hex_Digit}"
 );
-assert(
-  /^\p{Hex}+$/u.test(matchSymbols),
-  "`\\p{Hex}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Hex}+$/u,
+  matchSymbols,
+  "\\p{Hex}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,11 +49,13 @@ const nonMatchSymbols = buildString({
     [0x00FF47, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Hex_Digit}+$/u.test(nonMatchSymbols),
-  "`\\P{Hex_Digit}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Hex_Digit}+$/u,
+  nonMatchSymbols,
+  "\\P{Hex_Digit}"
 );
-assert(
-  /^\P{Hex}+$/u.test(nonMatchSymbols),
-  "`\\P{Hex}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Hex}+$/u,
+  nonMatchSymbols,
+  "\\P{Hex}"
 );

--- a/output/IDS_Binary_Operator.js
+++ b/output/IDS_Binary_Operator.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,13 +20,15 @@ const matchSymbols = buildString({
     [0x002FF4, 0x002FFB]
   ]
 });
-assert(
-  /^\p{IDS_Binary_Operator}+$/u.test(matchSymbols),
-  "`\\p{IDS_Binary_Operator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{IDS_Binary_Operator}+$/u,
+  matchSymbols,
+  "\\p{IDS_Binary_Operator}"
 );
-assert(
-  /^\p{IDSB}+$/u.test(matchSymbols),
-  "`\\p{IDSB}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{IDSB}+$/u,
+  matchSymbols,
+  "\\p{IDSB}"
 );
 
 const nonMatchSymbols = buildString({
@@ -39,11 +41,13 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{IDS_Binary_Operator}+$/u.test(nonMatchSymbols),
-  "`\\P{IDS_Binary_Operator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{IDS_Binary_Operator}+$/u,
+  nonMatchSymbols,
+  "\\P{IDS_Binary_Operator}"
 );
-assert(
-  /^\P{IDSB}+$/u.test(nonMatchSymbols),
-  "`\\P{IDSB}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{IDSB}+$/u,
+  nonMatchSymbols,
+  "\\P{IDSB}"
 );

--- a/output/IDS_Trinary_Operator.js
+++ b/output/IDS_Trinary_Operator.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,13 +19,15 @@ const matchSymbols = buildString({
     [0x002FF2, 0x002FF3]
   ]
 });
-assert(
-  /^\p{IDS_Trinary_Operator}+$/u.test(matchSymbols),
-  "`\\p{IDS_Trinary_Operator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{IDS_Trinary_Operator}+$/u,
+  matchSymbols,
+  "\\p{IDS_Trinary_Operator}"
 );
-assert(
-  /^\p{IDST}+$/u.test(matchSymbols),
-  "`\\p{IDST}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{IDST}+$/u,
+  matchSymbols,
+  "\\p{IDST}"
 );
 
 const nonMatchSymbols = buildString({
@@ -37,11 +39,13 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{IDS_Trinary_Operator}+$/u.test(nonMatchSymbols),
-  "`\\P{IDS_Trinary_Operator}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{IDS_Trinary_Operator}+$/u,
+  nonMatchSymbols,
+  "\\P{IDS_Trinary_Operator}"
 );
-assert(
-  /^\P{IDST}+$/u.test(nonMatchSymbols),
-  "`\\P{IDST}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{IDST}+$/u,
+  nonMatchSymbols,
+  "\\P{IDST}"
 );

--- a/output/ID_Continue.js
+++ b/output/ID_Continue.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -695,13 +695,15 @@ const matchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\p{ID_Continue}+$/u.test(matchSymbols),
-  "`\\p{ID_Continue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{ID_Continue}+$/u,
+  matchSymbols,
+  "\\p{ID_Continue}"
 );
-assert(
-  /^\p{IDC}+$/u.test(matchSymbols),
-  "`\\p{IDC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{IDC}+$/u,
+  matchSymbols,
+  "\\p{IDC}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1389,11 +1391,13 @@ const nonMatchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{ID_Continue}+$/u.test(nonMatchSymbols),
-  "`\\P{ID_Continue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{ID_Continue}+$/u,
+  nonMatchSymbols,
+  "\\P{ID_Continue}"
 );
-assert(
-  /^\P{IDC}+$/u.test(nonMatchSymbols),
-  "`\\P{IDC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{IDC}+$/u,
+  nonMatchSymbols,
+  "\\P{IDC}"
 );

--- a/output/ID_Start.js
+++ b/output/ID_Start.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -590,13 +590,15 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{ID_Start}+$/u.test(matchSymbols),
-  "`\\p{ID_Start}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{ID_Start}+$/u,
+  matchSymbols,
+  "\\p{ID_Start}"
 );
-assert(
-  /^\p{IDS}+$/u.test(matchSymbols),
-  "`\\p{IDS}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{IDS}+$/u,
+  matchSymbols,
+  "\\p{IDS}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1179,11 +1181,13 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{ID_Start}+$/u.test(nonMatchSymbols),
-  "`\\P{ID_Start}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{ID_Start}+$/u,
+  nonMatchSymbols,
+  "\\P{ID_Start}"
 );
-assert(
-  /^\P{IDS}+$/u.test(nonMatchSymbols),
-  "`\\P{IDS}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{IDS}+$/u,
+  nonMatchSymbols,
+  "\\P{IDS}"
 );

--- a/output/Ideographic.js
+++ b/output/Ideographic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -32,13 +32,15 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{Ideographic}+$/u.test(matchSymbols),
-  "`\\p{Ideographic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Ideographic}+$/u,
+  matchSymbols,
+  "\\p{Ideographic}"
 );
-assert(
-  /^\p{Ideo}+$/u.test(matchSymbols),
-  "`\\p{Ideo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Ideo}+$/u,
+  matchSymbols,
+  "\\p{Ideo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -63,11 +65,13 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Ideographic}+$/u.test(nonMatchSymbols),
-  "`\\P{Ideographic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Ideographic}+$/u,
+  nonMatchSymbols,
+  "\\P{Ideographic}"
 );
-assert(
-  /^\P{Ideo}+$/u.test(nonMatchSymbols),
-  "`\\P{Ideo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Ideo}+$/u,
+  nonMatchSymbols,
+  "\\P{Ideo}"
 );

--- a/output/Join_Control.js
+++ b/output/Join_Control.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,13 +19,15 @@ const matchSymbols = buildString({
     [0x00200C, 0x00200D]
   ]
 });
-assert(
-  /^\p{Join_Control}+$/u.test(matchSymbols),
-  "`\\p{Join_Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Join_Control}+$/u,
+  matchSymbols,
+  "\\p{Join_Control}"
 );
-assert(
-  /^\p{Join_C}+$/u.test(matchSymbols),
-  "`\\p{Join_C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Join_C}+$/u,
+  matchSymbols,
+  "\\p{Join_C}"
 );
 
 const nonMatchSymbols = buildString({
@@ -37,11 +39,13 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Join_Control}+$/u.test(nonMatchSymbols),
-  "`\\P{Join_Control}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Join_Control}+$/u,
+  nonMatchSymbols,
+  "\\P{Join_Control}"
 );
-assert(
-  /^\P{Join_C}+$/u.test(nonMatchSymbols),
-  "`\\P{Join_C}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Join_C}+$/u,
+  nonMatchSymbols,
+  "\\P{Join_C}"
 );

--- a/output/Logical_Order_Exception.js
+++ b/output/Logical_Order_Exception.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -26,13 +26,15 @@ const matchSymbols = buildString({
     [0x00AABB, 0x00AABC]
   ]
 });
-assert(
-  /^\p{Logical_Order_Exception}+$/u.test(matchSymbols),
-  "`\\p{Logical_Order_Exception}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Logical_Order_Exception}+$/u,
+  matchSymbols,
+  "\\p{Logical_Order_Exception}"
 );
-assert(
-  /^\p{LOE}+$/u.test(matchSymbols),
-  "`\\p{LOE}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{LOE}+$/u,
+  matchSymbols,
+  "\\p{LOE}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,11 +53,13 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Logical_Order_Exception}+$/u.test(nonMatchSymbols),
-  "`\\P{Logical_Order_Exception}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Logical_Order_Exception}+$/u,
+  nonMatchSymbols,
+  "\\P{Logical_Order_Exception}"
 );
-assert(
-  /^\P{LOE}+$/u.test(nonMatchSymbols),
-  "`\\P{LOE}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{LOE}+$/u,
+  nonMatchSymbols,
+  "\\P{LOE}"
 );

--- a/output/Lowercase.js
+++ b/output/Lowercase.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -659,13 +659,15 @@ const matchSymbols = buildString({
     [0x01E922, 0x01E943]
   ]
 });
-assert(
-  /^\p{Lowercase}+$/u.test(matchSymbols),
-  "`\\p{Lowercase}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Lowercase}+$/u,
+  matchSymbols,
+  "\\p{Lowercase}"
 );
-assert(
-  /^\p{Lower}+$/u.test(matchSymbols),
-  "`\\p{Lower}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Lower}+$/u,
+  matchSymbols,
+  "\\p{Lower}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1317,11 +1319,13 @@ const nonMatchSymbols = buildString({
     [0x01E944, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Lowercase}+$/u.test(nonMatchSymbols),
-  "`\\P{Lowercase}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Lowercase}+$/u,
+  nonMatchSymbols,
+  "\\P{Lowercase}"
 );
-assert(
-  /^\P{Lower}+$/u.test(nonMatchSymbols),
-  "`\\P{Lower}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Lower}+$/u,
+  nonMatchSymbols,
+  "\\P{Lower}"
 );

--- a/output/Math.js
+++ b/output/Math.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -157,9 +157,10 @@ const matchSymbols = buildString({
     [0x01EEF0, 0x01EEF1]
   ]
 });
-assert(
-  /^\p{Math}+$/u.test(matchSymbols),
-  "`\\p{Math}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Math}+$/u,
+  matchSymbols,
+  "\\p{Math}"
 );
 
 const nonMatchSymbols = buildString({
@@ -309,7 +310,8 @@ const nonMatchSymbols = buildString({
     [0x01EEF2, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Math}+$/u.test(nonMatchSymbols),
-  "`\\P{Math}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Math}+$/u,
+  nonMatchSymbols,
+  "\\P{Math}"
 );

--- a/output/Noncharacter_Code_Point.js
+++ b/output/Noncharacter_Code_Point.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -36,13 +36,15 @@ const matchSymbols = buildString({
     [0x10FFFE, 0x10FFFF]
   ]
 });
-assert(
-  /^\p{Noncharacter_Code_Point}+$/u.test(matchSymbols),
-  "`\\p{Noncharacter_Code_Point}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Noncharacter_Code_Point}+$/u,
+  matchSymbols,
+  "\\p{Noncharacter_Code_Point}"
 );
-assert(
-  /^\p{NChar}+$/u.test(matchSymbols),
-  "`\\p{NChar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{NChar}+$/u,
+  matchSymbols,
+  "\\p{NChar}"
 );
 
 const nonMatchSymbols = buildString({
@@ -70,11 +72,13 @@ const nonMatchSymbols = buildString({
     [0x100000, 0x10FFFD]
   ]
 });
-assert(
-  /^\P{Noncharacter_Code_Point}+$/u.test(nonMatchSymbols),
-  "`\\P{Noncharacter_Code_Point}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Noncharacter_Code_Point}+$/u,
+  nonMatchSymbols,
+  "\\P{Noncharacter_Code_Point}"
 );
-assert(
-  /^\P{NChar}+$/u.test(nonMatchSymbols),
-  "`\\P{NChar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{NChar}+$/u,
+  nonMatchSymbols,
+  "\\P{NChar}"
 );

--- a/output/Pattern_Syntax.js
+++ b/output/Pattern_Syntax.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -47,13 +47,15 @@ const matchSymbols = buildString({
     [0x00FE45, 0x00FE46]
   ]
 });
-assert(
-  /^\p{Pattern_Syntax}+$/u.test(matchSymbols),
-  "`\\p{Pattern_Syntax}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Pattern_Syntax}+$/u,
+  matchSymbols,
+  "\\p{Pattern_Syntax}"
 );
-assert(
-  /^\p{Pat_Syn}+$/u.test(matchSymbols),
-  "`\\p{Pat_Syn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Pat_Syn}+$/u,
+  matchSymbols,
+  "\\p{Pat_Syn}"
 );
 
 const nonMatchSymbols = buildString({
@@ -93,11 +95,13 @@ const nonMatchSymbols = buildString({
     [0x00FE47, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Pattern_Syntax}+$/u.test(nonMatchSymbols),
-  "`\\P{Pattern_Syntax}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Pattern_Syntax}+$/u,
+  nonMatchSymbols,
+  "\\P{Pattern_Syntax}"
 );
-assert(
-  /^\P{Pat_Syn}+$/u.test(nonMatchSymbols),
-  "`\\P{Pat_Syn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Pat_Syn}+$/u,
+  nonMatchSymbols,
+  "\\P{Pat_Syn}"
 );

--- a/output/Pattern_White_Space.js
+++ b/output/Pattern_White_Space.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -24,13 +24,15 @@ const matchSymbols = buildString({
     [0x002028, 0x002029]
   ]
 });
-assert(
-  /^\p{Pattern_White_Space}+$/u.test(matchSymbols),
-  "`\\p{Pattern_White_Space}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Pattern_White_Space}+$/u,
+  matchSymbols,
+  "\\p{Pattern_White_Space}"
 );
-assert(
-  /^\p{Pat_WS}+$/u.test(matchSymbols),
-  "`\\p{Pat_WS}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Pat_WS}+$/u,
+  matchSymbols,
+  "\\p{Pat_WS}"
 );
 
 const nonMatchSymbols = buildString({
@@ -46,11 +48,13 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Pattern_White_Space}+$/u.test(nonMatchSymbols),
-  "`\\P{Pattern_White_Space}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Pattern_White_Space}+$/u,
+  nonMatchSymbols,
+  "\\P{Pattern_White_Space}"
 );
-assert(
-  /^\P{Pat_WS}+$/u.test(nonMatchSymbols),
-  "`\\P{Pat_WS}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Pat_WS}+$/u,
+  nonMatchSymbols,
+  "\\P{Pat_WS}"
 );

--- a/output/Prepended_Concatenation_Mark.js
+++ b/output/Prepended_Concatenation_Mark.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -24,13 +24,15 @@ const matchSymbols = buildString({
     [0x000600, 0x000605]
   ]
 });
-assert(
-  /^\p{Prepended_Concatenation_Mark}+$/u.test(matchSymbols),
-  "`\\p{Prepended_Concatenation_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Prepended_Concatenation_Mark}+$/u,
+  matchSymbols,
+  "\\p{Prepended_Concatenation_Mark}"
 );
-assert(
-  /^\p{PCM}+$/u.test(matchSymbols),
-  "`\\p{PCM}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{PCM}+$/u,
+  matchSymbols,
+  "\\p{PCM}"
 );
 
 const nonMatchSymbols = buildString({
@@ -46,11 +48,13 @@ const nonMatchSymbols = buildString({
     [0x0110BE, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Prepended_Concatenation_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{Prepended_Concatenation_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Prepended_Concatenation_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{Prepended_Concatenation_Mark}"
 );
-assert(
-  /^\P{PCM}+$/u.test(nonMatchSymbols),
-  "`\\P{PCM}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{PCM}+$/u,
+  nonMatchSymbols,
+  "\\P{PCM}"
 );

--- a/output/Quotation_Mark.js
+++ b/output/Quotation_Mark.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -32,13 +32,15 @@ const matchSymbols = buildString({
     [0x00FF62, 0x00FF63]
   ]
 });
-assert(
-  /^\p{Quotation_Mark}+$/u.test(matchSymbols),
-  "`\\p{Quotation_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Quotation_Mark}+$/u,
+  matchSymbols,
+  "\\p{Quotation_Mark}"
 );
-assert(
-  /^\p{QMark}+$/u.test(matchSymbols),
-  "`\\p{QMark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{QMark}+$/u,
+  matchSymbols,
+  "\\p{QMark}"
 );
 
 const nonMatchSymbols = buildString({
@@ -62,11 +64,13 @@ const nonMatchSymbols = buildString({
     [0x00FF64, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Quotation_Mark}+$/u.test(nonMatchSymbols),
-  "`\\P{Quotation_Mark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Quotation_Mark}+$/u,
+  nonMatchSymbols,
+  "\\P{Quotation_Mark}"
 );
-assert(
-  /^\P{QMark}+$/u.test(nonMatchSymbols),
-  "`\\P{QMark}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{QMark}+$/u,
+  nonMatchSymbols,
+  "\\P{QMark}"
 );

--- a/output/Radical.js
+++ b/output/Radical.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,9 +21,10 @@ const matchSymbols = buildString({
     [0x002F00, 0x002FD5]
   ]
 });
-assert(
-  /^\p{Radical}+$/u.test(matchSymbols),
-  "`\\p{Radical}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Radical}+$/u,
+  matchSymbols,
+  "\\p{Radical}"
 );
 
 const nonMatchSymbols = buildString({
@@ -38,7 +39,8 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Radical}+$/u.test(nonMatchSymbols),
-  "`\\P{Radical}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Radical}+$/u,
+  nonMatchSymbols,
+  "\\P{Radical}"
 );

--- a/output/Script_-_Adlam.js
+++ b/output/Script_-_Adlam.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x01E95E, 0x01E95F]
   ]
 });
-assert(
-  /^\p{Script=Adlam}+$/u.test(matchSymbols),
-  "`\\p{Script=Adlam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Adlam}+$/u,
+  matchSymbols,
+  "\\p{Script=Adlam}"
 );
-assert(
-  /^\p{Script=Adlm}+$/u.test(matchSymbols),
-  "`\\p{Script=Adlm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Adlm}+$/u,
+  matchSymbols,
+  "\\p{Script=Adlm}"
 );
-assert(
-  /^\p{sc=Adlam}+$/u.test(matchSymbols),
-  "`\\p{sc=Adlam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Adlam}+$/u,
+  matchSymbols,
+  "\\p{sc=Adlam}"
 );
-assert(
-  /^\p{sc=Adlm}+$/u.test(matchSymbols),
-  "`\\p{sc=Adlm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Adlm}+$/u,
+  matchSymbols,
+  "\\p{sc=Adlm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x01E960, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Adlam}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Adlam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Adlam}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Adlam}"
 );
-assert(
-  /^\P{Script=Adlm}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Adlm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Adlm}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Adlm}"
 );
-assert(
-  /^\P{sc=Adlam}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Adlam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Adlam}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Adlam}"
 );
-assert(
-  /^\P{sc=Adlm}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Adlm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Adlm}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Adlm}"
 );

--- a/output/Script_-_Ahom.js
+++ b/output/Script_-_Ahom.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x011730, 0x01173F]
   ]
 });
-assert(
-  /^\p{Script=Ahom}+$/u.test(matchSymbols),
-  "`\\p{Script=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ahom}+$/u,
+  matchSymbols,
+  "\\p{Script=Ahom}"
 );
-assert(
-  /^\p{Script=Ahom}+$/u.test(matchSymbols),
-  "`\\p{Script=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ahom}+$/u,
+  matchSymbols,
+  "\\p{Script=Ahom}"
 );
-assert(
-  /^\p{sc=Ahom}+$/u.test(matchSymbols),
-  "`\\p{sc=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ahom}+$/u,
+  matchSymbols,
+  "\\p{sc=Ahom}"
 );
-assert(
-  /^\p{sc=Ahom}+$/u.test(matchSymbols),
-  "`\\p{sc=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ahom}+$/u,
+  matchSymbols,
+  "\\p{sc=Ahom}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x011740, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Ahom}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ahom}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ahom}"
 );
-assert(
-  /^\P{Script=Ahom}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ahom}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ahom}"
 );
-assert(
-  /^\P{sc=Ahom}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ahom}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ahom}"
 );
-assert(
-  /^\P{sc=Ahom}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ahom}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ahom}"
 );

--- a/output/Script_-_Anatolian_Hieroglyphs.js
+++ b/output/Script_-_Anatolian_Hieroglyphs.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x014400, 0x014646]
   ]
 });
-assert(
-  /^\p{Script=Anatolian_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{Script=Anatolian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Anatolian_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{Script=Anatolian_Hieroglyphs}"
 );
-assert(
-  /^\p{Script=Hluw}+$/u.test(matchSymbols),
-  "`\\p{Script=Hluw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hluw}+$/u,
+  matchSymbols,
+  "\\p{Script=Hluw}"
 );
-assert(
-  /^\p{sc=Anatolian_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{sc=Anatolian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Anatolian_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{sc=Anatolian_Hieroglyphs}"
 );
-assert(
-  /^\p{sc=Hluw}+$/u.test(matchSymbols),
-  "`\\p{sc=Hluw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hluw}+$/u,
+  matchSymbols,
+  "\\p{sc=Hluw}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x014647, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Anatolian_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Anatolian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Anatolian_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Anatolian_Hieroglyphs}"
 );
-assert(
-  /^\P{Script=Hluw}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hluw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hluw}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hluw}"
 );
-assert(
-  /^\P{sc=Anatolian_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Anatolian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Anatolian_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Anatolian_Hieroglyphs}"
 );
-assert(
-  /^\P{sc=Hluw}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hluw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hluw}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hluw}"
 );

--- a/output/Script_-_Arabic.js
+++ b/output/Script_-_Arabic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -75,21 +75,25 @@ const matchSymbols = buildString({
     [0x01EEF0, 0x01EEF1]
   ]
 });
-assert(
-  /^\p{Script=Arabic}+$/u.test(matchSymbols),
-  "`\\p{Script=Arabic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Arabic}+$/u,
+  matchSymbols,
+  "\\p{Script=Arabic}"
 );
-assert(
-  /^\p{Script=Arab}+$/u.test(matchSymbols),
-  "`\\p{Script=Arab}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Arab}+$/u,
+  matchSymbols,
+  "\\p{Script=Arab}"
 );
-assert(
-  /^\p{sc=Arabic}+$/u.test(matchSymbols),
-  "`\\p{sc=Arabic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Arabic}+$/u,
+  matchSymbols,
+  "\\p{sc=Arabic}"
 );
-assert(
-  /^\p{sc=Arab}+$/u.test(matchSymbols),
-  "`\\p{sc=Arab}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Arab}+$/u,
+  matchSymbols,
+  "\\p{sc=Arab}"
 );
 
 const nonMatchSymbols = buildString({
@@ -157,19 +161,23 @@ const nonMatchSymbols = buildString({
     [0x01EEF2, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Arabic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Arabic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Arabic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Arabic}"
 );
-assert(
-  /^\P{Script=Arab}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Arab}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Arab}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Arab}"
 );
-assert(
-  /^\P{sc=Arabic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Arabic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Arabic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Arabic}"
 );
-assert(
-  /^\P{sc=Arab}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Arab}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Arab}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Arab}"
 );

--- a/output/Script_-_Armenian.js
+++ b/output/Script_-_Armenian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,21 +25,25 @@ const matchSymbols = buildString({
     [0x00FB13, 0x00FB17]
   ]
 });
-assert(
-  /^\p{Script=Armenian}+$/u.test(matchSymbols),
-  "`\\p{Script=Armenian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Armenian}+$/u,
+  matchSymbols,
+  "\\p{Script=Armenian}"
 );
-assert(
-  /^\p{Script=Armn}+$/u.test(matchSymbols),
-  "`\\p{Script=Armn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Armn}+$/u,
+  matchSymbols,
+  "\\p{Script=Armn}"
 );
-assert(
-  /^\p{sc=Armenian}+$/u.test(matchSymbols),
-  "`\\p{sc=Armenian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Armenian}+$/u,
+  matchSymbols,
+  "\\p{sc=Armenian}"
 );
-assert(
-  /^\p{sc=Armn}+$/u.test(matchSymbols),
-  "`\\p{sc=Armn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Armn}+$/u,
+  matchSymbols,
+  "\\p{sc=Armn}"
 );
 
 const nonMatchSymbols = buildString({
@@ -57,19 +61,23 @@ const nonMatchSymbols = buildString({
     [0x00FB18, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Armenian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Armenian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Armenian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Armenian}"
 );
-assert(
-  /^\P{Script=Armn}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Armn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Armn}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Armn}"
 );
-assert(
-  /^\P{sc=Armenian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Armenian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Armenian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Armenian}"
 );
-assert(
-  /^\P{sc=Armn}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Armn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Armn}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Armn}"
 );

--- a/output/Script_-_Avestan.js
+++ b/output/Script_-_Avestan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x010B39, 0x010B3F]
   ]
 });
-assert(
-  /^\p{Script=Avestan}+$/u.test(matchSymbols),
-  "`\\p{Script=Avestan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Avestan}+$/u,
+  matchSymbols,
+  "\\p{Script=Avestan}"
 );
-assert(
-  /^\p{Script=Avst}+$/u.test(matchSymbols),
-  "`\\p{Script=Avst}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Avst}+$/u,
+  matchSymbols,
+  "\\p{Script=Avst}"
 );
-assert(
-  /^\p{sc=Avestan}+$/u.test(matchSymbols),
-  "`\\p{sc=Avestan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Avestan}+$/u,
+  matchSymbols,
+  "\\p{sc=Avestan}"
 );
-assert(
-  /^\p{sc=Avst}+$/u.test(matchSymbols),
-  "`\\p{sc=Avst}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Avst}+$/u,
+  matchSymbols,
+  "\\p{sc=Avst}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x010B40, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Avestan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Avestan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Avestan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Avestan}"
 );
-assert(
-  /^\P{Script=Avst}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Avst}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Avst}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Avst}"
 );
-assert(
-  /^\P{sc=Avestan}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Avestan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Avestan}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Avestan}"
 );
-assert(
-  /^\P{sc=Avst}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Avst}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Avst}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Avst}"
 );

--- a/output/Script_-_Balinese.js
+++ b/output/Script_-_Balinese.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x001B50, 0x001B7C]
   ]
 });
-assert(
-  /^\p{Script=Balinese}+$/u.test(matchSymbols),
-  "`\\p{Script=Balinese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Balinese}+$/u,
+  matchSymbols,
+  "\\p{Script=Balinese}"
 );
-assert(
-  /^\p{Script=Bali}+$/u.test(matchSymbols),
-  "`\\p{Script=Bali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bali}+$/u,
+  matchSymbols,
+  "\\p{Script=Bali}"
 );
-assert(
-  /^\p{sc=Balinese}+$/u.test(matchSymbols),
-  "`\\p{sc=Balinese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Balinese}+$/u,
+  matchSymbols,
+  "\\p{sc=Balinese}"
 );
-assert(
-  /^\p{sc=Bali}+$/u.test(matchSymbols),
-  "`\\p{sc=Bali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bali}+$/u,
+  matchSymbols,
+  "\\p{sc=Bali}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Balinese}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Balinese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Balinese}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Balinese}"
 );
-assert(
-  /^\P{Script=Bali}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bali}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bali}"
 );
-assert(
-  /^\P{sc=Balinese}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Balinese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Balinese}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Balinese}"
 );
-assert(
-  /^\P{sc=Bali}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bali}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bali}"
 );

--- a/output/Script_-_Bamum.js
+++ b/output/Script_-_Bamum.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x016800, 0x016A38]
   ]
 });
-assert(
-  /^\p{Script=Bamum}+$/u.test(matchSymbols),
-  "`\\p{Script=Bamum}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bamum}+$/u,
+  matchSymbols,
+  "\\p{Script=Bamum}"
 );
-assert(
-  /^\p{Script=Bamu}+$/u.test(matchSymbols),
-  "`\\p{Script=Bamu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bamu}+$/u,
+  matchSymbols,
+  "\\p{Script=Bamu}"
 );
-assert(
-  /^\p{sc=Bamum}+$/u.test(matchSymbols),
-  "`\\p{sc=Bamum}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bamum}+$/u,
+  matchSymbols,
+  "\\p{sc=Bamum}"
 );
-assert(
-  /^\p{sc=Bamu}+$/u.test(matchSymbols),
-  "`\\p{sc=Bamu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bamu}+$/u,
+  matchSymbols,
+  "\\p{sc=Bamu}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x016A39, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Bamum}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bamum}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bamum}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bamum}"
 );
-assert(
-  /^\P{Script=Bamu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bamu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bamu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bamu}"
 );
-assert(
-  /^\P{sc=Bamum}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bamum}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bamum}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bamum}"
 );
-assert(
-  /^\P{sc=Bamu}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bamu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bamu}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bamu}"
 );

--- a/output/Script_-_Bassa_Vah.js
+++ b/output/Script_-_Bassa_Vah.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x016AF0, 0x016AF5]
   ]
 });
-assert(
-  /^\p{Script=Bassa_Vah}+$/u.test(matchSymbols),
-  "`\\p{Script=Bassa_Vah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bassa_Vah}+$/u,
+  matchSymbols,
+  "\\p{Script=Bassa_Vah}"
 );
-assert(
-  /^\p{Script=Bass}+$/u.test(matchSymbols),
-  "`\\p{Script=Bass}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bass}+$/u,
+  matchSymbols,
+  "\\p{Script=Bass}"
 );
-assert(
-  /^\p{sc=Bassa_Vah}+$/u.test(matchSymbols),
-  "`\\p{sc=Bassa_Vah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bassa_Vah}+$/u,
+  matchSymbols,
+  "\\p{sc=Bassa_Vah}"
 );
-assert(
-  /^\p{sc=Bass}+$/u.test(matchSymbols),
-  "`\\p{sc=Bass}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bass}+$/u,
+  matchSymbols,
+  "\\p{sc=Bass}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x016AF6, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Bassa_Vah}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bassa_Vah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bassa_Vah}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bassa_Vah}"
 );
-assert(
-  /^\P{Script=Bass}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bass}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bass}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bass}"
 );
-assert(
-  /^\P{sc=Bassa_Vah}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bassa_Vah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bassa_Vah}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bassa_Vah}"
 );
-assert(
-  /^\P{sc=Bass}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bass}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bass}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bass}"
 );

--- a/output/Script_-_Batak.js
+++ b/output/Script_-_Batak.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x001BFC, 0x001BFF]
   ]
 });
-assert(
-  /^\p{Script=Batak}+$/u.test(matchSymbols),
-  "`\\p{Script=Batak}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Batak}+$/u,
+  matchSymbols,
+  "\\p{Script=Batak}"
 );
-assert(
-  /^\p{Script=Batk}+$/u.test(matchSymbols),
-  "`\\p{Script=Batk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Batk}+$/u,
+  matchSymbols,
+  "\\p{Script=Batk}"
 );
-assert(
-  /^\p{sc=Batak}+$/u.test(matchSymbols),
-  "`\\p{sc=Batak}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Batak}+$/u,
+  matchSymbols,
+  "\\p{sc=Batak}"
 );
-assert(
-  /^\p{sc=Batk}+$/u.test(matchSymbols),
-  "`\\p{sc=Batk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Batk}+$/u,
+  matchSymbols,
+  "\\p{sc=Batk}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Batak}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Batak}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Batak}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Batak}"
 );
-assert(
-  /^\P{Script=Batk}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Batk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Batk}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Batk}"
 );
-assert(
-  /^\P{sc=Batak}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Batak}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Batak}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Batak}"
 );
-assert(
-  /^\P{sc=Batk}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Batk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Batk}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Batk}"
 );

--- a/output/Script_-_Bengali.js
+++ b/output/Script_-_Bengali.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -33,21 +33,25 @@ const matchSymbols = buildString({
     [0x0009E6, 0x0009FB]
   ]
 });
-assert(
-  /^\p{Script=Bengali}+$/u.test(matchSymbols),
-  "`\\p{Script=Bengali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bengali}+$/u,
+  matchSymbols,
+  "\\p{Script=Bengali}"
 );
-assert(
-  /^\p{Script=Beng}+$/u.test(matchSymbols),
-  "`\\p{Script=Beng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Beng}+$/u,
+  matchSymbols,
+  "\\p{Script=Beng}"
 );
-assert(
-  /^\p{sc=Bengali}+$/u.test(matchSymbols),
-  "`\\p{sc=Bengali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bengali}+$/u,
+  matchSymbols,
+  "\\p{sc=Bengali}"
 );
-assert(
-  /^\p{sc=Beng}+$/u.test(matchSymbols),
-  "`\\p{sc=Beng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Beng}+$/u,
+  matchSymbols,
+  "\\p{sc=Beng}"
 );
 
 const nonMatchSymbols = buildString({
@@ -73,19 +77,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Bengali}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bengali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bengali}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bengali}"
 );
-assert(
-  /^\P{Script=Beng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Beng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Beng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Beng}"
 );
-assert(
-  /^\P{sc=Bengali}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bengali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bengali}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bengali}"
 );
-assert(
-  /^\P{sc=Beng}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Beng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Beng}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Beng}"
 );

--- a/output/Script_-_Bhaiksuki.js
+++ b/output/Script_-_Bhaiksuki.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x011C50, 0x011C6C]
   ]
 });
-assert(
-  /^\p{Script=Bhaiksuki}+$/u.test(matchSymbols),
-  "`\\p{Script=Bhaiksuki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bhaiksuki}+$/u,
+  matchSymbols,
+  "\\p{Script=Bhaiksuki}"
 );
-assert(
-  /^\p{Script=Bhks}+$/u.test(matchSymbols),
-  "`\\p{Script=Bhks}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bhks}+$/u,
+  matchSymbols,
+  "\\p{Script=Bhks}"
 );
-assert(
-  /^\p{sc=Bhaiksuki}+$/u.test(matchSymbols),
-  "`\\p{sc=Bhaiksuki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bhaiksuki}+$/u,
+  matchSymbols,
+  "\\p{sc=Bhaiksuki}"
 );
-assert(
-  /^\p{sc=Bhks}+$/u.test(matchSymbols),
-  "`\\p{sc=Bhks}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bhks}+$/u,
+  matchSymbols,
+  "\\p{sc=Bhks}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x011C6D, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Bhaiksuki}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bhaiksuki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bhaiksuki}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bhaiksuki}"
 );
-assert(
-  /^\P{Script=Bhks}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bhks}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bhks}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bhks}"
 );
-assert(
-  /^\P{sc=Bhaiksuki}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bhaiksuki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bhaiksuki}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bhaiksuki}"
 );
-assert(
-  /^\P{sc=Bhks}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bhks}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bhks}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bhks}"
 );

--- a/output/Script_-_Bopomofo.js
+++ b/output/Script_-_Bopomofo.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x0031A0, 0x0031BA]
   ]
 });
-assert(
-  /^\p{Script=Bopomofo}+$/u.test(matchSymbols),
-  "`\\p{Script=Bopomofo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bopomofo}+$/u,
+  matchSymbols,
+  "\\p{Script=Bopomofo}"
 );
-assert(
-  /^\p{Script=Bopo}+$/u.test(matchSymbols),
-  "`\\p{Script=Bopo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bopo}+$/u,
+  matchSymbols,
+  "\\p{Script=Bopo}"
 );
-assert(
-  /^\p{sc=Bopomofo}+$/u.test(matchSymbols),
-  "`\\p{sc=Bopomofo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bopomofo}+$/u,
+  matchSymbols,
+  "\\p{sc=Bopomofo}"
 );
-assert(
-  /^\p{sc=Bopo}+$/u.test(matchSymbols),
-  "`\\p{sc=Bopo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bopo}+$/u,
+  matchSymbols,
+  "\\p{sc=Bopo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Bopomofo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bopomofo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bopomofo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bopomofo}"
 );
-assert(
-  /^\P{Script=Bopo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bopo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bopo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bopo}"
 );
-assert(
-  /^\P{sc=Bopomofo}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bopomofo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bopomofo}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bopomofo}"
 );
-assert(
-  /^\P{sc=Bopo}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bopo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bopo}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bopo}"
 );

--- a/output/Script_-_Brahmi.js
+++ b/output/Script_-_Brahmi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x011052, 0x01106F]
   ]
 });
-assert(
-  /^\p{Script=Brahmi}+$/u.test(matchSymbols),
-  "`\\p{Script=Brahmi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Brahmi}+$/u,
+  matchSymbols,
+  "\\p{Script=Brahmi}"
 );
-assert(
-  /^\p{Script=Brah}+$/u.test(matchSymbols),
-  "`\\p{Script=Brah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Brah}+$/u,
+  matchSymbols,
+  "\\p{Script=Brah}"
 );
-assert(
-  /^\p{sc=Brahmi}+$/u.test(matchSymbols),
-  "`\\p{sc=Brahmi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Brahmi}+$/u,
+  matchSymbols,
+  "\\p{sc=Brahmi}"
 );
-assert(
-  /^\p{sc=Brah}+$/u.test(matchSymbols),
-  "`\\p{sc=Brah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Brah}+$/u,
+  matchSymbols,
+  "\\p{sc=Brah}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x011080, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Brahmi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Brahmi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Brahmi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Brahmi}"
 );
-assert(
-  /^\P{Script=Brah}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Brah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Brah}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Brah}"
 );
-assert(
-  /^\P{sc=Brahmi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Brahmi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Brahmi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Brahmi}"
 );
-assert(
-  /^\P{sc=Brah}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Brah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Brah}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Brah}"
 );

--- a/output/Script_-_Braille.js
+++ b/output/Script_-_Braille.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x002800, 0x0028FF]
   ]
 });
-assert(
-  /^\p{Script=Braille}+$/u.test(matchSymbols),
-  "`\\p{Script=Braille}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Braille}+$/u,
+  matchSymbols,
+  "\\p{Script=Braille}"
 );
-assert(
-  /^\p{Script=Brai}+$/u.test(matchSymbols),
-  "`\\p{Script=Brai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Brai}+$/u,
+  matchSymbols,
+  "\\p{Script=Brai}"
 );
-assert(
-  /^\p{sc=Braille}+$/u.test(matchSymbols),
-  "`\\p{sc=Braille}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Braille}+$/u,
+  matchSymbols,
+  "\\p{sc=Braille}"
 );
-assert(
-  /^\p{sc=Brai}+$/u.test(matchSymbols),
-  "`\\p{sc=Brai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Brai}+$/u,
+  matchSymbols,
+  "\\p{sc=Brai}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Braille}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Braille}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Braille}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Braille}"
 );
-assert(
-  /^\P{Script=Brai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Brai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Brai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Brai}"
 );
-assert(
-  /^\P{sc=Braille}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Braille}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Braille}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Braille}"
 );
-assert(
-  /^\P{sc=Brai}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Brai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Brai}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Brai}"
 );

--- a/output/Script_-_Buginese.js
+++ b/output/Script_-_Buginese.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x001A1E, 0x001A1F]
   ]
 });
-assert(
-  /^\p{Script=Buginese}+$/u.test(matchSymbols),
-  "`\\p{Script=Buginese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Buginese}+$/u,
+  matchSymbols,
+  "\\p{Script=Buginese}"
 );
-assert(
-  /^\p{Script=Bugi}+$/u.test(matchSymbols),
-  "`\\p{Script=Bugi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Bugi}+$/u,
+  matchSymbols,
+  "\\p{Script=Bugi}"
 );
-assert(
-  /^\p{sc=Buginese}+$/u.test(matchSymbols),
-  "`\\p{sc=Buginese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Buginese}+$/u,
+  matchSymbols,
+  "\\p{sc=Buginese}"
 );
-assert(
-  /^\p{sc=Bugi}+$/u.test(matchSymbols),
-  "`\\p{sc=Bugi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Bugi}+$/u,
+  matchSymbols,
+  "\\p{sc=Bugi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Buginese}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Buginese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Buginese}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Buginese}"
 );
-assert(
-  /^\P{Script=Bugi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Bugi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Bugi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Bugi}"
 );
-assert(
-  /^\P{sc=Buginese}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Buginese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Buginese}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Buginese}"
 );
-assert(
-  /^\P{sc=Bugi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Bugi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Bugi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Bugi}"
 );

--- a/output/Script_-_Buhid.js
+++ b/output/Script_-_Buhid.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x001740, 0x001753]
   ]
 });
-assert(
-  /^\p{Script=Buhid}+$/u.test(matchSymbols),
-  "`\\p{Script=Buhid}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Buhid}+$/u,
+  matchSymbols,
+  "\\p{Script=Buhid}"
 );
-assert(
-  /^\p{Script=Buhd}+$/u.test(matchSymbols),
-  "`\\p{Script=Buhd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Buhd}+$/u,
+  matchSymbols,
+  "\\p{Script=Buhd}"
 );
-assert(
-  /^\p{sc=Buhid}+$/u.test(matchSymbols),
-  "`\\p{sc=Buhid}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Buhid}+$/u,
+  matchSymbols,
+  "\\p{sc=Buhid}"
 );
-assert(
-  /^\p{sc=Buhd}+$/u.test(matchSymbols),
-  "`\\p{sc=Buhd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Buhd}+$/u,
+  matchSymbols,
+  "\\p{sc=Buhd}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Buhid}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Buhid}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Buhid}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Buhid}"
 );
-assert(
-  /^\P{Script=Buhd}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Buhd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Buhd}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Buhd}"
 );
-assert(
-  /^\P{sc=Buhid}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Buhid}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Buhid}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Buhid}"
 );
-assert(
-  /^\P{sc=Buhd}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Buhd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Buhd}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Buhd}"
 );

--- a/output/Script_-_Canadian_Aboriginal.js
+++ b/output/Script_-_Canadian_Aboriginal.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0018B0, 0x0018F5]
   ]
 });
-assert(
-  /^\p{Script=Canadian_Aboriginal}+$/u.test(matchSymbols),
-  "`\\p{Script=Canadian_Aboriginal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Canadian_Aboriginal}+$/u,
+  matchSymbols,
+  "\\p{Script=Canadian_Aboriginal}"
 );
-assert(
-  /^\p{Script=Cans}+$/u.test(matchSymbols),
-  "`\\p{Script=Cans}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cans}+$/u,
+  matchSymbols,
+  "\\p{Script=Cans}"
 );
-assert(
-  /^\p{sc=Canadian_Aboriginal}+$/u.test(matchSymbols),
-  "`\\p{sc=Canadian_Aboriginal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Canadian_Aboriginal}+$/u,
+  matchSymbols,
+  "\\p{sc=Canadian_Aboriginal}"
 );
-assert(
-  /^\p{sc=Cans}+$/u.test(matchSymbols),
-  "`\\p{sc=Cans}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cans}+$/u,
+  matchSymbols,
+  "\\p{sc=Cans}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Canadian_Aboriginal}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Canadian_Aboriginal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Canadian_Aboriginal}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Canadian_Aboriginal}"
 );
-assert(
-  /^\P{Script=Cans}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cans}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cans}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cans}"
 );
-assert(
-  /^\P{sc=Canadian_Aboriginal}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Canadian_Aboriginal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Canadian_Aboriginal}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Canadian_Aboriginal}"
 );
-assert(
-  /^\P{sc=Cans}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cans}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cans}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cans}"
 );

--- a/output/Script_-_Carian.js
+++ b/output/Script_-_Carian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x0102A0, 0x0102D0]
   ]
 });
-assert(
-  /^\p{Script=Carian}+$/u.test(matchSymbols),
-  "`\\p{Script=Carian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Carian}+$/u,
+  matchSymbols,
+  "\\p{Script=Carian}"
 );
-assert(
-  /^\p{Script=Cari}+$/u.test(matchSymbols),
-  "`\\p{Script=Cari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cari}+$/u,
+  matchSymbols,
+  "\\p{Script=Cari}"
 );
-assert(
-  /^\p{sc=Carian}+$/u.test(matchSymbols),
-  "`\\p{sc=Carian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Carian}+$/u,
+  matchSymbols,
+  "\\p{sc=Carian}"
 );
-assert(
-  /^\p{sc=Cari}+$/u.test(matchSymbols),
-  "`\\p{sc=Cari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cari}+$/u,
+  matchSymbols,
+  "\\p{sc=Cari}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x0102D1, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Carian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Carian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Carian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Carian}"
 );
-assert(
-  /^\P{Script=Cari}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cari}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cari}"
 );
-assert(
-  /^\P{sc=Carian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Carian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Carian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Carian}"
 );
-assert(
-  /^\P{sc=Cari}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cari}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cari}"
 );

--- a/output/Script_-_Caucasian_Albanian.js
+++ b/output/Script_-_Caucasian_Albanian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010530, 0x010563]
   ]
 });
-assert(
-  /^\p{Script=Caucasian_Albanian}+$/u.test(matchSymbols),
-  "`\\p{Script=Caucasian_Albanian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Caucasian_Albanian}+$/u,
+  matchSymbols,
+  "\\p{Script=Caucasian_Albanian}"
 );
-assert(
-  /^\p{Script=Aghb}+$/u.test(matchSymbols),
-  "`\\p{Script=Aghb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Aghb}+$/u,
+  matchSymbols,
+  "\\p{Script=Aghb}"
 );
-assert(
-  /^\p{sc=Caucasian_Albanian}+$/u.test(matchSymbols),
-  "`\\p{sc=Caucasian_Albanian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Caucasian_Albanian}+$/u,
+  matchSymbols,
+  "\\p{sc=Caucasian_Albanian}"
 );
-assert(
-  /^\p{sc=Aghb}+$/u.test(matchSymbols),
-  "`\\p{sc=Aghb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Aghb}+$/u,
+  matchSymbols,
+  "\\p{sc=Aghb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x010570, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Caucasian_Albanian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Caucasian_Albanian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Caucasian_Albanian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Caucasian_Albanian}"
 );
-assert(
-  /^\P{Script=Aghb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Aghb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Aghb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Aghb}"
 );
-assert(
-  /^\P{sc=Caucasian_Albanian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Caucasian_Albanian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Caucasian_Albanian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Caucasian_Albanian}"
 );
-assert(
-  /^\P{sc=Aghb}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Aghb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Aghb}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Aghb}"
 );

--- a/output/Script_-_Chakma.js
+++ b/output/Script_-_Chakma.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x011136, 0x011143]
   ]
 });
-assert(
-  /^\p{Script=Chakma}+$/u.test(matchSymbols),
-  "`\\p{Script=Chakma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Chakma}+$/u,
+  matchSymbols,
+  "\\p{Script=Chakma}"
 );
-assert(
-  /^\p{Script=Cakm}+$/u.test(matchSymbols),
-  "`\\p{Script=Cakm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cakm}+$/u,
+  matchSymbols,
+  "\\p{Script=Cakm}"
 );
-assert(
-  /^\p{sc=Chakma}+$/u.test(matchSymbols),
-  "`\\p{sc=Chakma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Chakma}+$/u,
+  matchSymbols,
+  "\\p{sc=Chakma}"
 );
-assert(
-  /^\p{sc=Cakm}+$/u.test(matchSymbols),
-  "`\\p{sc=Cakm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cakm}+$/u,
+  matchSymbols,
+  "\\p{sc=Cakm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x011144, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Chakma}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Chakma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Chakma}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Chakma}"
 );
-assert(
-  /^\P{Script=Cakm}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cakm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cakm}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cakm}"
 );
-assert(
-  /^\P{sc=Chakma}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Chakma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Chakma}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Chakma}"
 );
-assert(
-  /^\P{sc=Cakm}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cakm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cakm}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cakm}"
 );

--- a/output/Script_-_Cham.js
+++ b/output/Script_-_Cham.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x00AA5C, 0x00AA5F]
   ]
 });
-assert(
-  /^\p{Script=Cham}+$/u.test(matchSymbols),
-  "`\\p{Script=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cham}+$/u,
+  matchSymbols,
+  "\\p{Script=Cham}"
 );
-assert(
-  /^\p{Script=Cham}+$/u.test(matchSymbols),
-  "`\\p{Script=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cham}+$/u,
+  matchSymbols,
+  "\\p{Script=Cham}"
 );
-assert(
-  /^\p{sc=Cham}+$/u.test(matchSymbols),
-  "`\\p{sc=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cham}+$/u,
+  matchSymbols,
+  "\\p{sc=Cham}"
 );
-assert(
-  /^\p{sc=Cham}+$/u.test(matchSymbols),
-  "`\\p{sc=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cham}+$/u,
+  matchSymbols,
+  "\\p{sc=Cham}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Cham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cham}"
 );
-assert(
-  /^\P{Script=Cham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cham}"
 );
-assert(
-  /^\P{sc=Cham}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cham}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cham}"
 );
-assert(
-  /^\P{sc=Cham}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cham}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cham}"
 );

--- a/output/Script_-_Cherokee.js
+++ b/output/Script_-_Cherokee.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00AB70, 0x00ABBF]
   ]
 });
-assert(
-  /^\p{Script=Cherokee}+$/u.test(matchSymbols),
-  "`\\p{Script=Cherokee}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cherokee}+$/u,
+  matchSymbols,
+  "\\p{Script=Cherokee}"
 );
-assert(
-  /^\p{Script=Cher}+$/u.test(matchSymbols),
-  "`\\p{Script=Cher}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cher}+$/u,
+  matchSymbols,
+  "\\p{Script=Cher}"
 );
-assert(
-  /^\p{sc=Cherokee}+$/u.test(matchSymbols),
-  "`\\p{sc=Cherokee}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cherokee}+$/u,
+  matchSymbols,
+  "\\p{sc=Cherokee}"
 );
-assert(
-  /^\p{sc=Cher}+$/u.test(matchSymbols),
-  "`\\p{sc=Cher}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cher}+$/u,
+  matchSymbols,
+  "\\p{sc=Cher}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Cherokee}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cherokee}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cherokee}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cherokee}"
 );
-assert(
-  /^\P{Script=Cher}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cher}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cher}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cher}"
 );
-assert(
-  /^\P{sc=Cherokee}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cherokee}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cherokee}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cherokee}"
 );
-assert(
-  /^\P{sc=Cher}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cher}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cher}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cher}"
 );

--- a/output/Script_-_Common.js
+++ b/output/Script_-_Common.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -184,21 +184,25 @@ const matchSymbols = buildString({
     [0x0E0020, 0x0E007F]
   ]
 });
-assert(
-  /^\p{Script=Common}+$/u.test(matchSymbols),
-  "`\\p{Script=Common}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Common}+$/u,
+  matchSymbols,
+  "\\p{Script=Common}"
 );
-assert(
-  /^\p{Script=Zyyy}+$/u.test(matchSymbols),
-  "`\\p{Script=Zyyy}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Zyyy}+$/u,
+  matchSymbols,
+  "\\p{Script=Zyyy}"
 );
-assert(
-  /^\p{sc=Common}+$/u.test(matchSymbols),
-  "`\\p{sc=Common}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Common}+$/u,
+  matchSymbols,
+  "\\p{sc=Common}"
 );
-assert(
-  /^\p{sc=Zyyy}+$/u.test(matchSymbols),
-  "`\\p{sc=Zyyy}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Zyyy}+$/u,
+  matchSymbols,
+  "\\p{sc=Zyyy}"
 );
 
 const nonMatchSymbols = buildString({
@@ -374,19 +378,23 @@ const nonMatchSymbols = buildString({
     [0x0E0080, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Common}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Common}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Common}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Common}"
 );
-assert(
-  /^\P{Script=Zyyy}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Zyyy}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Zyyy}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Zyyy}"
 );
-assert(
-  /^\P{sc=Common}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Common}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Common}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Common}"
 );
-assert(
-  /^\P{sc=Zyyy}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Zyyy}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Zyyy}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Zyyy}"
 );

--- a/output/Script_-_Coptic.js
+++ b/output/Script_-_Coptic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,29 +21,35 @@ const matchSymbols = buildString({
     [0x002CF9, 0x002CFF]
   ]
 });
-assert(
-  /^\p{Script=Coptic}+$/u.test(matchSymbols),
-  "`\\p{Script=Coptic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Coptic}+$/u,
+  matchSymbols,
+  "\\p{Script=Coptic}"
 );
-assert(
-  /^\p{Script=Copt}+$/u.test(matchSymbols),
-  "`\\p{Script=Copt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Copt}+$/u,
+  matchSymbols,
+  "\\p{Script=Copt}"
 );
-assert(
-  /^\p{Script=Qaac}+$/u.test(matchSymbols),
-  "`\\p{Script=Qaac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Qaac}+$/u,
+  matchSymbols,
+  "\\p{Script=Qaac}"
 );
-assert(
-  /^\p{sc=Coptic}+$/u.test(matchSymbols),
-  "`\\p{sc=Coptic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Coptic}+$/u,
+  matchSymbols,
+  "\\p{sc=Coptic}"
 );
-assert(
-  /^\p{sc=Copt}+$/u.test(matchSymbols),
-  "`\\p{sc=Copt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Copt}+$/u,
+  matchSymbols,
+  "\\p{sc=Copt}"
 );
-assert(
-  /^\p{sc=Qaac}+$/u.test(matchSymbols),
-  "`\\p{sc=Qaac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Qaac}+$/u,
+  matchSymbols,
+  "\\p{sc=Qaac}"
 );
 
 const nonMatchSymbols = buildString({
@@ -57,27 +63,33 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Coptic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Coptic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Coptic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Coptic}"
 );
-assert(
-  /^\P{Script=Copt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Copt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Copt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Copt}"
 );
-assert(
-  /^\P{Script=Qaac}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Qaac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Qaac}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Qaac}"
 );
-assert(
-  /^\P{sc=Coptic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Coptic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Coptic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Coptic}"
 );
-assert(
-  /^\P{sc=Copt}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Copt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Copt}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Copt}"
 );
-assert(
-  /^\P{sc=Qaac}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Qaac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Qaac}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Qaac}"
 );

--- a/output/Script_-_Cuneiform.js
+++ b/output/Script_-_Cuneiform.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x012480, 0x012543]
   ]
 });
-assert(
-  /^\p{Script=Cuneiform}+$/u.test(matchSymbols),
-  "`\\p{Script=Cuneiform}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cuneiform}+$/u,
+  matchSymbols,
+  "\\p{Script=Cuneiform}"
 );
-assert(
-  /^\p{Script=Xsux}+$/u.test(matchSymbols),
-  "`\\p{Script=Xsux}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Xsux}+$/u,
+  matchSymbols,
+  "\\p{Script=Xsux}"
 );
-assert(
-  /^\p{sc=Cuneiform}+$/u.test(matchSymbols),
-  "`\\p{sc=Cuneiform}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cuneiform}+$/u,
+  matchSymbols,
+  "\\p{sc=Cuneiform}"
 );
-assert(
-  /^\p{sc=Xsux}+$/u.test(matchSymbols),
-  "`\\p{sc=Xsux}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Xsux}+$/u,
+  matchSymbols,
+  "\\p{sc=Xsux}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x012544, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Cuneiform}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cuneiform}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cuneiform}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cuneiform}"
 );
-assert(
-  /^\P{Script=Xsux}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Xsux}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Xsux}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Xsux}"
 );
-assert(
-  /^\P{sc=Cuneiform}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cuneiform}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cuneiform}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cuneiform}"
 );
-assert(
-  /^\P{sc=Xsux}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Xsux}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Xsux}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Xsux}"
 );

--- a/output/Script_-_Cypriot.js
+++ b/output/Script_-_Cypriot.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,21 +25,25 @@ const matchSymbols = buildString({
     [0x010837, 0x010838]
   ]
 });
-assert(
-  /^\p{Script=Cypriot}+$/u.test(matchSymbols),
-  "`\\p{Script=Cypriot}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cypriot}+$/u,
+  matchSymbols,
+  "\\p{Script=Cypriot}"
 );
-assert(
-  /^\p{Script=Cprt}+$/u.test(matchSymbols),
-  "`\\p{Script=Cprt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cprt}+$/u,
+  matchSymbols,
+  "\\p{Script=Cprt}"
 );
-assert(
-  /^\p{sc=Cypriot}+$/u.test(matchSymbols),
-  "`\\p{sc=Cypriot}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cypriot}+$/u,
+  matchSymbols,
+  "\\p{sc=Cypriot}"
 );
-assert(
-  /^\p{sc=Cprt}+$/u.test(matchSymbols),
-  "`\\p{sc=Cprt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cprt}+$/u,
+  matchSymbols,
+  "\\p{sc=Cprt}"
 );
 
 const nonMatchSymbols = buildString({
@@ -57,19 +61,23 @@ const nonMatchSymbols = buildString({
     [0x010840, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Cypriot}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cypriot}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cypriot}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cypriot}"
 );
-assert(
-  /^\P{Script=Cprt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cprt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cprt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cprt}"
 );
-assert(
-  /^\P{sc=Cypriot}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cypriot}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cypriot}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cypriot}"
 );
-assert(
-  /^\P{sc=Cprt}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cprt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cprt}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cprt}"
 );

--- a/output/Script_-_Cyrillic.js
+++ b/output/Script_-_Cyrillic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -27,21 +27,25 @@ const matchSymbols = buildString({
     [0x00FE2E, 0x00FE2F]
   ]
 });
-assert(
-  /^\p{Script=Cyrillic}+$/u.test(matchSymbols),
-  "`\\p{Script=Cyrillic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cyrillic}+$/u,
+  matchSymbols,
+  "\\p{Script=Cyrillic}"
 );
-assert(
-  /^\p{Script=Cyrl}+$/u.test(matchSymbols),
-  "`\\p{Script=Cyrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Cyrl}+$/u,
+  matchSymbols,
+  "\\p{Script=Cyrl}"
 );
-assert(
-  /^\p{sc=Cyrillic}+$/u.test(matchSymbols),
-  "`\\p{sc=Cyrillic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cyrillic}+$/u,
+  matchSymbols,
+  "\\p{sc=Cyrillic}"
 );
-assert(
-  /^\p{sc=Cyrl}+$/u.test(matchSymbols),
-  "`\\p{sc=Cyrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Cyrl}+$/u,
+  matchSymbols,
+  "\\p{sc=Cyrl}"
 );
 
 const nonMatchSymbols = buildString({
@@ -60,19 +64,23 @@ const nonMatchSymbols = buildString({
     [0x00FE30, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Cyrillic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cyrillic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cyrillic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cyrillic}"
 );
-assert(
-  /^\P{Script=Cyrl}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Cyrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Cyrl}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Cyrl}"
 );
-assert(
-  /^\P{sc=Cyrillic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cyrillic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cyrillic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cyrillic}"
 );
-assert(
-  /^\P{sc=Cyrl}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Cyrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Cyrl}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Cyrl}"
 );

--- a/output/Script_-_Deseret.js
+++ b/output/Script_-_Deseret.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010400, 0x01044F]
   ]
 });
-assert(
-  /^\p{Script=Deseret}+$/u.test(matchSymbols),
-  "`\\p{Script=Deseret}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Deseret}+$/u,
+  matchSymbols,
+  "\\p{Script=Deseret}"
 );
-assert(
-  /^\p{Script=Dsrt}+$/u.test(matchSymbols),
-  "`\\p{Script=Dsrt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Dsrt}+$/u,
+  matchSymbols,
+  "\\p{Script=Dsrt}"
 );
-assert(
-  /^\p{sc=Deseret}+$/u.test(matchSymbols),
-  "`\\p{sc=Deseret}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Deseret}+$/u,
+  matchSymbols,
+  "\\p{sc=Deseret}"
 );
-assert(
-  /^\p{sc=Dsrt}+$/u.test(matchSymbols),
-  "`\\p{sc=Dsrt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Dsrt}+$/u,
+  matchSymbols,
+  "\\p{sc=Dsrt}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010450, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Deseret}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Deseret}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Deseret}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Deseret}"
 );
-assert(
-  /^\P{Script=Dsrt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Dsrt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Dsrt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Dsrt}"
 );
-assert(
-  /^\P{sc=Deseret}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Deseret}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Deseret}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Deseret}"
 );
-assert(
-  /^\P{sc=Dsrt}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Dsrt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Dsrt}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Dsrt}"
 );

--- a/output/Script_-_Devanagari.js
+++ b/output/Script_-_Devanagari.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x00A8E0, 0x00A8FD]
   ]
 });
-assert(
-  /^\p{Script=Devanagari}+$/u.test(matchSymbols),
-  "`\\p{Script=Devanagari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Devanagari}+$/u,
+  matchSymbols,
+  "\\p{Script=Devanagari}"
 );
-assert(
-  /^\p{Script=Deva}+$/u.test(matchSymbols),
-  "`\\p{Script=Deva}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Deva}+$/u,
+  matchSymbols,
+  "\\p{Script=Deva}"
 );
-assert(
-  /^\p{sc=Devanagari}+$/u.test(matchSymbols),
-  "`\\p{sc=Devanagari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Devanagari}+$/u,
+  matchSymbols,
+  "\\p{sc=Devanagari}"
 );
-assert(
-  /^\p{sc=Deva}+$/u.test(matchSymbols),
-  "`\\p{sc=Deva}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Deva}+$/u,
+  matchSymbols,
+  "\\p{sc=Deva}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Devanagari}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Devanagari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Devanagari}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Devanagari}"
 );
-assert(
-  /^\P{Script=Deva}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Deva}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Deva}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Deva}"
 );
-assert(
-  /^\P{sc=Devanagari}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Devanagari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Devanagari}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Devanagari}"
 );
-assert(
-  /^\P{sc=Deva}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Deva}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Deva}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Deva}"
 );

--- a/output/Script_-_Duployan.js
+++ b/output/Script_-_Duployan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x01BC9C, 0x01BC9F]
   ]
 });
-assert(
-  /^\p{Script=Duployan}+$/u.test(matchSymbols),
-  "`\\p{Script=Duployan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Duployan}+$/u,
+  matchSymbols,
+  "\\p{Script=Duployan}"
 );
-assert(
-  /^\p{Script=Dupl}+$/u.test(matchSymbols),
-  "`\\p{Script=Dupl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Dupl}+$/u,
+  matchSymbols,
+  "\\p{Script=Dupl}"
 );
-assert(
-  /^\p{sc=Duployan}+$/u.test(matchSymbols),
-  "`\\p{sc=Duployan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Duployan}+$/u,
+  matchSymbols,
+  "\\p{sc=Duployan}"
 );
-assert(
-  /^\p{sc=Dupl}+$/u.test(matchSymbols),
-  "`\\p{sc=Dupl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Dupl}+$/u,
+  matchSymbols,
+  "\\p{sc=Dupl}"
 );
 
 const nonMatchSymbols = buildString({
@@ -53,19 +57,23 @@ const nonMatchSymbols = buildString({
     [0x01BCA0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Duployan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Duployan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Duployan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Duployan}"
 );
-assert(
-  /^\P{Script=Dupl}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Dupl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Dupl}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Dupl}"
 );
-assert(
-  /^\P{sc=Duployan}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Duployan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Duployan}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Duployan}"
 );
-assert(
-  /^\P{sc=Dupl}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Dupl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Dupl}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Dupl}"
 );

--- a/output/Script_-_Egyptian_Hieroglyphs.js
+++ b/output/Script_-_Egyptian_Hieroglyphs.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x013000, 0x01342E]
   ]
 });
-assert(
-  /^\p{Script=Egyptian_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{Script=Egyptian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Egyptian_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{Script=Egyptian_Hieroglyphs}"
 );
-assert(
-  /^\p{Script=Egyp}+$/u.test(matchSymbols),
-  "`\\p{Script=Egyp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Egyp}+$/u,
+  matchSymbols,
+  "\\p{Script=Egyp}"
 );
-assert(
-  /^\p{sc=Egyptian_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{sc=Egyptian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Egyptian_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{sc=Egyptian_Hieroglyphs}"
 );
-assert(
-  /^\p{sc=Egyp}+$/u.test(matchSymbols),
-  "`\\p{sc=Egyp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Egyp}+$/u,
+  matchSymbols,
+  "\\p{sc=Egyp}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x01342F, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Egyptian_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Egyptian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Egyptian_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Egyptian_Hieroglyphs}"
 );
-assert(
-  /^\P{Script=Egyp}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Egyp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Egyp}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Egyp}"
 );
-assert(
-  /^\P{sc=Egyptian_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Egyptian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Egyptian_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Egyptian_Hieroglyphs}"
 );
-assert(
-  /^\P{sc=Egyp}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Egyp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Egyp}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Egyp}"
 );

--- a/output/Script_-_Elbasan.js
+++ b/output/Script_-_Elbasan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010500, 0x010527]
   ]
 });
-assert(
-  /^\p{Script=Elbasan}+$/u.test(matchSymbols),
-  "`\\p{Script=Elbasan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Elbasan}+$/u,
+  matchSymbols,
+  "\\p{Script=Elbasan}"
 );
-assert(
-  /^\p{Script=Elba}+$/u.test(matchSymbols),
-  "`\\p{Script=Elba}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Elba}+$/u,
+  matchSymbols,
+  "\\p{Script=Elba}"
 );
-assert(
-  /^\p{sc=Elbasan}+$/u.test(matchSymbols),
-  "`\\p{sc=Elbasan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Elbasan}+$/u,
+  matchSymbols,
+  "\\p{sc=Elbasan}"
 );
-assert(
-  /^\p{sc=Elba}+$/u.test(matchSymbols),
-  "`\\p{sc=Elba}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Elba}+$/u,
+  matchSymbols,
+  "\\p{sc=Elba}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010528, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Elbasan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Elbasan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Elbasan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Elbasan}"
 );
-assert(
-  /^\P{Script=Elba}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Elba}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Elba}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Elba}"
 );
-assert(
-  /^\P{sc=Elbasan}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Elbasan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Elbasan}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Elbasan}"
 );
-assert(
-  /^\P{sc=Elba}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Elba}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Elba}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Elba}"
 );

--- a/output/Script_-_Ethiopic.js
+++ b/output/Script_-_Ethiopic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -51,21 +51,25 @@ const matchSymbols = buildString({
     [0x00AB28, 0x00AB2E]
   ]
 });
-assert(
-  /^\p{Script=Ethiopic}+$/u.test(matchSymbols),
-  "`\\p{Script=Ethiopic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ethiopic}+$/u,
+  matchSymbols,
+  "\\p{Script=Ethiopic}"
 );
-assert(
-  /^\p{Script=Ethi}+$/u.test(matchSymbols),
-  "`\\p{Script=Ethi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ethi}+$/u,
+  matchSymbols,
+  "\\p{Script=Ethi}"
 );
-assert(
-  /^\p{sc=Ethiopic}+$/u.test(matchSymbols),
-  "`\\p{sc=Ethiopic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ethiopic}+$/u,
+  matchSymbols,
+  "\\p{sc=Ethiopic}"
 );
-assert(
-  /^\p{sc=Ethi}+$/u.test(matchSymbols),
-  "`\\p{sc=Ethi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ethi}+$/u,
+  matchSymbols,
+  "\\p{sc=Ethi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -109,19 +113,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Ethiopic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ethiopic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ethiopic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ethiopic}"
 );
-assert(
-  /^\P{Script=Ethi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ethi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ethi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ethi}"
 );
-assert(
-  /^\P{sc=Ethiopic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ethiopic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ethiopic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ethiopic}"
 );
-assert(
-  /^\P{sc=Ethi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ethi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ethi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ethi}"
 );

--- a/output/Script_-_Georgian.js
+++ b/output/Script_-_Georgian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -27,21 +27,25 @@ const matchSymbols = buildString({
     [0x002D00, 0x002D25]
   ]
 });
-assert(
-  /^\p{Script=Georgian}+$/u.test(matchSymbols),
-  "`\\p{Script=Georgian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Georgian}+$/u,
+  matchSymbols,
+  "\\p{Script=Georgian}"
 );
-assert(
-  /^\p{Script=Geor}+$/u.test(matchSymbols),
-  "`\\p{Script=Geor}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Geor}+$/u,
+  matchSymbols,
+  "\\p{Script=Geor}"
 );
-assert(
-  /^\p{sc=Georgian}+$/u.test(matchSymbols),
-  "`\\p{sc=Georgian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Georgian}+$/u,
+  matchSymbols,
+  "\\p{sc=Georgian}"
 );
-assert(
-  /^\p{sc=Geor}+$/u.test(matchSymbols),
-  "`\\p{sc=Geor}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Geor}+$/u,
+  matchSymbols,
+  "\\p{sc=Geor}"
 );
 
 const nonMatchSymbols = buildString({
@@ -61,19 +65,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Georgian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Georgian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Georgian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Georgian}"
 );
-assert(
-  /^\P{Script=Geor}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Geor}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Geor}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Geor}"
 );
-assert(
-  /^\P{sc=Georgian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Georgian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Georgian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Georgian}"
 );
-assert(
-  /^\P{sc=Geor}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Geor}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Geor}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Geor}"
 );

--- a/output/Script_-_Glagolitic.js
+++ b/output/Script_-_Glagolitic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,21 +25,25 @@ const matchSymbols = buildString({
     [0x01E026, 0x01E02A]
   ]
 });
-assert(
-  /^\p{Script=Glagolitic}+$/u.test(matchSymbols),
-  "`\\p{Script=Glagolitic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Glagolitic}+$/u,
+  matchSymbols,
+  "\\p{Script=Glagolitic}"
 );
-assert(
-  /^\p{Script=Glag}+$/u.test(matchSymbols),
-  "`\\p{Script=Glag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Glag}+$/u,
+  matchSymbols,
+  "\\p{Script=Glag}"
 );
-assert(
-  /^\p{sc=Glagolitic}+$/u.test(matchSymbols),
-  "`\\p{sc=Glagolitic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Glagolitic}+$/u,
+  matchSymbols,
+  "\\p{sc=Glagolitic}"
 );
-assert(
-  /^\p{sc=Glag}+$/u.test(matchSymbols),
-  "`\\p{sc=Glag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Glag}+$/u,
+  matchSymbols,
+  "\\p{sc=Glag}"
 );
 
 const nonMatchSymbols = buildString({
@@ -58,19 +62,23 @@ const nonMatchSymbols = buildString({
     [0x01E02B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Glagolitic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Glagolitic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Glagolitic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Glagolitic}"
 );
-assert(
-  /^\P{Script=Glag}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Glag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Glag}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Glag}"
 );
-assert(
-  /^\P{sc=Glagolitic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Glagolitic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Glagolitic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Glagolitic}"
 );
-assert(
-  /^\P{sc=Glag}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Glag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Glag}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Glag}"
 );

--- a/output/Script_-_Gothic.js
+++ b/output/Script_-_Gothic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010330, 0x01034A]
   ]
 });
-assert(
-  /^\p{Script=Gothic}+$/u.test(matchSymbols),
-  "`\\p{Script=Gothic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Gothic}+$/u,
+  matchSymbols,
+  "\\p{Script=Gothic}"
 );
-assert(
-  /^\p{Script=Goth}+$/u.test(matchSymbols),
-  "`\\p{Script=Goth}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Goth}+$/u,
+  matchSymbols,
+  "\\p{Script=Goth}"
 );
-assert(
-  /^\p{sc=Gothic}+$/u.test(matchSymbols),
-  "`\\p{sc=Gothic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Gothic}+$/u,
+  matchSymbols,
+  "\\p{sc=Gothic}"
 );
-assert(
-  /^\p{sc=Goth}+$/u.test(matchSymbols),
-  "`\\p{sc=Goth}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Goth}+$/u,
+  matchSymbols,
+  "\\p{sc=Goth}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x01034B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Gothic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Gothic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Gothic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Gothic}"
 );
-assert(
-  /^\P{Script=Goth}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Goth}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Goth}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Goth}"
 );
-assert(
-  /^\P{sc=Gothic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Gothic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Gothic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Gothic}"
 );
-assert(
-  /^\P{sc=Goth}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Goth}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Goth}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Goth}"
 );

--- a/output/Script_-_Grantha.js
+++ b/output/Script_-_Grantha.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -34,21 +34,25 @@ const matchSymbols = buildString({
     [0x011370, 0x011374]
   ]
 });
-assert(
-  /^\p{Script=Grantha}+$/u.test(matchSymbols),
-  "`\\p{Script=Grantha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Grantha}+$/u,
+  matchSymbols,
+  "\\p{Script=Grantha}"
 );
-assert(
-  /^\p{Script=Gran}+$/u.test(matchSymbols),
-  "`\\p{Script=Gran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Gran}+$/u,
+  matchSymbols,
+  "\\p{Script=Gran}"
 );
-assert(
-  /^\p{sc=Grantha}+$/u.test(matchSymbols),
-  "`\\p{sc=Grantha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Grantha}+$/u,
+  matchSymbols,
+  "\\p{sc=Grantha}"
 );
-assert(
-  /^\p{sc=Gran}+$/u.test(matchSymbols),
-  "`\\p{sc=Gran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Gran}+$/u,
+  matchSymbols,
+  "\\p{sc=Gran}"
 );
 
 const nonMatchSymbols = buildString({
@@ -75,19 +79,23 @@ const nonMatchSymbols = buildString({
     [0x011375, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Grantha}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Grantha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Grantha}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Grantha}"
 );
-assert(
-  /^\P{Script=Gran}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Gran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Gran}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Gran}"
 );
-assert(
-  /^\P{sc=Grantha}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Grantha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Grantha}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Grantha}"
 );
-assert(
-  /^\P{sc=Gran}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Gran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Gran}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Gran}"
 );

--- a/output/Script_-_Greek.js
+++ b/output/Script_-_Greek.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -55,21 +55,25 @@ const matchSymbols = buildString({
     [0x01D200, 0x01D245]
   ]
 });
-assert(
-  /^\p{Script=Greek}+$/u.test(matchSymbols),
-  "`\\p{Script=Greek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Greek}+$/u,
+  matchSymbols,
+  "\\p{Script=Greek}"
 );
-assert(
-  /^\p{Script=Grek}+$/u.test(matchSymbols),
-  "`\\p{Script=Grek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Grek}+$/u,
+  matchSymbols,
+  "\\p{Script=Grek}"
 );
-assert(
-  /^\p{sc=Greek}+$/u.test(matchSymbols),
-  "`\\p{sc=Greek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Greek}+$/u,
+  matchSymbols,
+  "\\p{sc=Greek}"
 );
-assert(
-  /^\p{sc=Grek}+$/u.test(matchSymbols),
-  "`\\p{sc=Grek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Grek}+$/u,
+  matchSymbols,
+  "\\p{sc=Grek}"
 );
 
 const nonMatchSymbols = buildString({
@@ -117,19 +121,23 @@ const nonMatchSymbols = buildString({
     [0x01D246, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Greek}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Greek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Greek}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Greek}"
 );
-assert(
-  /^\P{Script=Grek}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Grek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Grek}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Grek}"
 );
-assert(
-  /^\P{sc=Greek}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Greek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Greek}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Greek}"
 );
-assert(
-  /^\P{sc=Grek}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Grek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Grek}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Grek}"
 );

--- a/output/Script_-_Gujarati.js
+++ b/output/Script_-_Gujarati.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -33,21 +33,25 @@ const matchSymbols = buildString({
     [0x000AE6, 0x000AF1]
   ]
 });
-assert(
-  /^\p{Script=Gujarati}+$/u.test(matchSymbols),
-  "`\\p{Script=Gujarati}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Gujarati}+$/u,
+  matchSymbols,
+  "\\p{Script=Gujarati}"
 );
-assert(
-  /^\p{Script=Gujr}+$/u.test(matchSymbols),
-  "`\\p{Script=Gujr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Gujr}+$/u,
+  matchSymbols,
+  "\\p{Script=Gujr}"
 );
-assert(
-  /^\p{sc=Gujarati}+$/u.test(matchSymbols),
-  "`\\p{sc=Gujarati}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Gujarati}+$/u,
+  matchSymbols,
+  "\\p{sc=Gujarati}"
 );
-assert(
-  /^\p{sc=Gujr}+$/u.test(matchSymbols),
-  "`\\p{sc=Gujr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Gujr}+$/u,
+  matchSymbols,
+  "\\p{sc=Gujr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -73,19 +77,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Gujarati}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Gujarati}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Gujarati}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Gujarati}"
 );
-assert(
-  /^\P{Script=Gujr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Gujr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Gujr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Gujr}"
 );
-assert(
-  /^\P{sc=Gujarati}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Gujarati}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Gujarati}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Gujarati}"
 );
-assert(
-  /^\P{sc=Gujr}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Gujr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Gujr}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Gujr}"
 );

--- a/output/Script_-_Gurmukhi.js
+++ b/output/Script_-_Gurmukhi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -35,21 +35,25 @@ const matchSymbols = buildString({
     [0x000A66, 0x000A75]
   ]
 });
-assert(
-  /^\p{Script=Gurmukhi}+$/u.test(matchSymbols),
-  "`\\p{Script=Gurmukhi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Gurmukhi}+$/u,
+  matchSymbols,
+  "\\p{Script=Gurmukhi}"
 );
-assert(
-  /^\p{Script=Guru}+$/u.test(matchSymbols),
-  "`\\p{Script=Guru}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Guru}+$/u,
+  matchSymbols,
+  "\\p{Script=Guru}"
 );
-assert(
-  /^\p{sc=Gurmukhi}+$/u.test(matchSymbols),
-  "`\\p{sc=Gurmukhi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Gurmukhi}+$/u,
+  matchSymbols,
+  "\\p{sc=Gurmukhi}"
 );
-assert(
-  /^\p{sc=Guru}+$/u.test(matchSymbols),
-  "`\\p{sc=Guru}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Guru}+$/u,
+  matchSymbols,
+  "\\p{sc=Guru}"
 );
 
 const nonMatchSymbols = buildString({
@@ -77,19 +81,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Gurmukhi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Gurmukhi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Gurmukhi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Gurmukhi}"
 );
-assert(
-  /^\P{Script=Guru}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Guru}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Guru}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Guru}"
 );
-assert(
-  /^\P{sc=Gurmukhi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Gurmukhi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Gurmukhi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Gurmukhi}"
 );
-assert(
-  /^\P{sc=Guru}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Guru}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Guru}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Guru}"
 );

--- a/output/Script_-_Han.js
+++ b/output/Script_-_Han.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -35,21 +35,25 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{Script=Han}+$/u.test(matchSymbols),
-  "`\\p{Script=Han}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Han}+$/u,
+  matchSymbols,
+  "\\p{Script=Han}"
 );
-assert(
-  /^\p{Script=Hani}+$/u.test(matchSymbols),
-  "`\\p{Script=Hani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hani}+$/u,
+  matchSymbols,
+  "\\p{Script=Hani}"
 );
-assert(
-  /^\p{sc=Han}+$/u.test(matchSymbols),
-  "`\\p{sc=Han}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Han}+$/u,
+  matchSymbols,
+  "\\p{sc=Han}"
 );
-assert(
-  /^\p{sc=Hani}+$/u.test(matchSymbols),
-  "`\\p{sc=Hani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hani}+$/u,
+  matchSymbols,
+  "\\p{sc=Hani}"
 );
 
 const nonMatchSymbols = buildString({
@@ -77,19 +81,23 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Han}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Han}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Han}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Han}"
 );
-assert(
-  /^\P{Script=Hani}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hani}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hani}"
 );
-assert(
-  /^\P{sc=Han}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Han}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Han}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Han}"
 );
-assert(
-  /^\P{sc=Hani}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hani}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hani}"
 );

--- a/output/Script_-_Hangul.js
+++ b/output/Script_-_Hangul.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -32,21 +32,25 @@ const matchSymbols = buildString({
     [0x00FFDA, 0x00FFDC]
   ]
 });
-assert(
-  /^\p{Script=Hangul}+$/u.test(matchSymbols),
-  "`\\p{Script=Hangul}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hangul}+$/u,
+  matchSymbols,
+  "\\p{Script=Hangul}"
 );
-assert(
-  /^\p{Script=Hang}+$/u.test(matchSymbols),
-  "`\\p{Script=Hang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hang}+$/u,
+  matchSymbols,
+  "\\p{Script=Hang}"
 );
-assert(
-  /^\p{sc=Hangul}+$/u.test(matchSymbols),
-  "`\\p{sc=Hangul}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hangul}+$/u,
+  matchSymbols,
+  "\\p{sc=Hangul}"
 );
-assert(
-  /^\p{sc=Hang}+$/u.test(matchSymbols),
-  "`\\p{sc=Hang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hang}+$/u,
+  matchSymbols,
+  "\\p{sc=Hang}"
 );
 
 const nonMatchSymbols = buildString({
@@ -71,19 +75,23 @@ const nonMatchSymbols = buildString({
     [0x00FFDD, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Hangul}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hangul}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hangul}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hangul}"
 );
-assert(
-  /^\P{Script=Hang}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hang}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hang}"
 );
-assert(
-  /^\P{sc=Hangul}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hangul}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hangul}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hangul}"
 );
-assert(
-  /^\P{sc=Hang}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hang}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hang}"
 );

--- a/output/Script_-_Hanunoo.js
+++ b/output/Script_-_Hanunoo.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x001720, 0x001734]
   ]
 });
-assert(
-  /^\p{Script=Hanunoo}+$/u.test(matchSymbols),
-  "`\\p{Script=Hanunoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hanunoo}+$/u,
+  matchSymbols,
+  "\\p{Script=Hanunoo}"
 );
-assert(
-  /^\p{Script=Hano}+$/u.test(matchSymbols),
-  "`\\p{Script=Hano}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hano}+$/u,
+  matchSymbols,
+  "\\p{Script=Hano}"
 );
-assert(
-  /^\p{sc=Hanunoo}+$/u.test(matchSymbols),
-  "`\\p{sc=Hanunoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hanunoo}+$/u,
+  matchSymbols,
+  "\\p{sc=Hanunoo}"
 );
-assert(
-  /^\p{sc=Hano}+$/u.test(matchSymbols),
-  "`\\p{sc=Hano}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hano}+$/u,
+  matchSymbols,
+  "\\p{sc=Hano}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Hanunoo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hanunoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hanunoo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hanunoo}"
 );
-assert(
-  /^\P{Script=Hano}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hano}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hano}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hano}"
 );
-assert(
-  /^\P{sc=Hanunoo}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hanunoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hanunoo}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hanunoo}"
 );
-assert(
-  /^\P{sc=Hano}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hano}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hano}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hano}"
 );

--- a/output/Script_-_Hatran.js
+++ b/output/Script_-_Hatran.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x0108FB, 0x0108FF]
   ]
 });
-assert(
-  /^\p{Script=Hatran}+$/u.test(matchSymbols),
-  "`\\p{Script=Hatran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hatran}+$/u,
+  matchSymbols,
+  "\\p{Script=Hatran}"
 );
-assert(
-  /^\p{Script=Hatr}+$/u.test(matchSymbols),
-  "`\\p{Script=Hatr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hatr}+$/u,
+  matchSymbols,
+  "\\p{Script=Hatr}"
 );
-assert(
-  /^\p{sc=Hatran}+$/u.test(matchSymbols),
-  "`\\p{sc=Hatran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hatran}+$/u,
+  matchSymbols,
+  "\\p{sc=Hatran}"
 );
-assert(
-  /^\p{sc=Hatr}+$/u.test(matchSymbols),
-  "`\\p{sc=Hatr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hatr}+$/u,
+  matchSymbols,
+  "\\p{sc=Hatr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x010900, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Hatran}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hatran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hatran}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hatran}"
 );
-assert(
-  /^\P{Script=Hatr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hatr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hatr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hatr}"
 );
-assert(
-  /^\P{sc=Hatran}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hatran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hatran}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hatran}"
 );
-assert(
-  /^\P{sc=Hatr}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hatr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hatr}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hatr}"
 );

--- a/output/Script_-_Hebrew.js
+++ b/output/Script_-_Hebrew.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -28,21 +28,25 @@ const matchSymbols = buildString({
     [0x00FB46, 0x00FB4F]
   ]
 });
-assert(
-  /^\p{Script=Hebrew}+$/u.test(matchSymbols),
-  "`\\p{Script=Hebrew}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hebrew}+$/u,
+  matchSymbols,
+  "\\p{Script=Hebrew}"
 );
-assert(
-  /^\p{Script=Hebr}+$/u.test(matchSymbols),
-  "`\\p{Script=Hebr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hebr}+$/u,
+  matchSymbols,
+  "\\p{Script=Hebr}"
 );
-assert(
-  /^\p{sc=Hebrew}+$/u.test(matchSymbols),
-  "`\\p{sc=Hebrew}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hebrew}+$/u,
+  matchSymbols,
+  "\\p{sc=Hebrew}"
 );
-assert(
-  /^\p{sc=Hebr}+$/u.test(matchSymbols),
-  "`\\p{sc=Hebr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hebr}+$/u,
+  matchSymbols,
+  "\\p{sc=Hebr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -63,19 +67,23 @@ const nonMatchSymbols = buildString({
     [0x00FB50, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Hebrew}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hebrew}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hebrew}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hebrew}"
 );
-assert(
-  /^\P{Script=Hebr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hebr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hebr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hebr}"
 );
-assert(
-  /^\P{sc=Hebrew}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hebrew}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hebrew}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hebrew}"
 );
-assert(
-  /^\P{sc=Hebr}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hebr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hebr}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hebr}"
 );

--- a/output/Script_-_Hiragana.js
+++ b/output/Script_-_Hiragana.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x00309D, 0x00309F]
   ]
 });
-assert(
-  /^\p{Script=Hiragana}+$/u.test(matchSymbols),
-  "`\\p{Script=Hiragana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hiragana}+$/u,
+  matchSymbols,
+  "\\p{Script=Hiragana}"
 );
-assert(
-  /^\p{Script=Hira}+$/u.test(matchSymbols),
-  "`\\p{Script=Hira}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hira}+$/u,
+  matchSymbols,
+  "\\p{Script=Hira}"
 );
-assert(
-  /^\p{sc=Hiragana}+$/u.test(matchSymbols),
-  "`\\p{sc=Hiragana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hiragana}+$/u,
+  matchSymbols,
+  "\\p{sc=Hiragana}"
 );
-assert(
-  /^\p{sc=Hira}+$/u.test(matchSymbols),
-  "`\\p{sc=Hira}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hira}+$/u,
+  matchSymbols,
+  "\\p{sc=Hira}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x01F201, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Hiragana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hiragana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hiragana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hiragana}"
 );
-assert(
-  /^\P{Script=Hira}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hira}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hira}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hira}"
 );
-assert(
-  /^\P{sc=Hiragana}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hiragana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hiragana}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hiragana}"
 );
-assert(
-  /^\P{sc=Hira}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hira}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hira}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hira}"
 );

--- a/output/Script_-_Imperial_Aramaic.js
+++ b/output/Script_-_Imperial_Aramaic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x010857, 0x01085F]
   ]
 });
-assert(
-  /^\p{Script=Imperial_Aramaic}+$/u.test(matchSymbols),
-  "`\\p{Script=Imperial_Aramaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Imperial_Aramaic}+$/u,
+  matchSymbols,
+  "\\p{Script=Imperial_Aramaic}"
 );
-assert(
-  /^\p{Script=Armi}+$/u.test(matchSymbols),
-  "`\\p{Script=Armi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Armi}+$/u,
+  matchSymbols,
+  "\\p{Script=Armi}"
 );
-assert(
-  /^\p{sc=Imperial_Aramaic}+$/u.test(matchSymbols),
-  "`\\p{sc=Imperial_Aramaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Imperial_Aramaic}+$/u,
+  matchSymbols,
+  "\\p{sc=Imperial_Aramaic}"
 );
-assert(
-  /^\p{sc=Armi}+$/u.test(matchSymbols),
-  "`\\p{sc=Armi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Armi}+$/u,
+  matchSymbols,
+  "\\p{sc=Armi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x010860, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Imperial_Aramaic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Imperial_Aramaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Imperial_Aramaic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Imperial_Aramaic}"
 );
-assert(
-  /^\P{Script=Armi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Armi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Armi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Armi}"
 );
-assert(
-  /^\P{sc=Imperial_Aramaic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Imperial_Aramaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Imperial_Aramaic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Imperial_Aramaic}"
 );
-assert(
-  /^\P{sc=Armi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Armi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Armi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Armi}"
 );

--- a/output/Script_-_Inherited.js
+++ b/output/Script_-_Inherited.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -46,29 +46,35 @@ const matchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\p{Script=Inherited}+$/u.test(matchSymbols),
-  "`\\p{Script=Inherited}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Inherited}+$/u,
+  matchSymbols,
+  "\\p{Script=Inherited}"
 );
-assert(
-  /^\p{Script=Zinh}+$/u.test(matchSymbols),
-  "`\\p{Script=Zinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Zinh}+$/u,
+  matchSymbols,
+  "\\p{Script=Zinh}"
 );
-assert(
-  /^\p{Script=Qaai}+$/u.test(matchSymbols),
-  "`\\p{Script=Qaai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Qaai}+$/u,
+  matchSymbols,
+  "\\p{Script=Qaai}"
 );
-assert(
-  /^\p{sc=Inherited}+$/u.test(matchSymbols),
-  "`\\p{sc=Inherited}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Inherited}+$/u,
+  matchSymbols,
+  "\\p{sc=Inherited}"
 );
-assert(
-  /^\p{sc=Zinh}+$/u.test(matchSymbols),
-  "`\\p{sc=Zinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Zinh}+$/u,
+  matchSymbols,
+  "\\p{sc=Zinh}"
 );
-assert(
-  /^\p{sc=Qaai}+$/u.test(matchSymbols),
-  "`\\p{sc=Qaai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Qaai}+$/u,
+  matchSymbols,
+  "\\p{sc=Qaai}"
 );
 
 const nonMatchSymbols = buildString({
@@ -107,27 +113,33 @@ const nonMatchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Inherited}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Inherited}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Inherited}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Inherited}"
 );
-assert(
-  /^\P{Script=Zinh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Zinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Zinh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Zinh}"
 );
-assert(
-  /^\P{Script=Qaai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Qaai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Qaai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Qaai}"
 );
-assert(
-  /^\P{sc=Inherited}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Inherited}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Inherited}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Inherited}"
 );
-assert(
-  /^\P{sc=Zinh}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Zinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Zinh}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Zinh}"
 );
-assert(
-  /^\P{sc=Qaai}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Qaai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Qaai}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Qaai}"
 );

--- a/output/Script_-_Inscriptional_Pahlavi.js
+++ b/output/Script_-_Inscriptional_Pahlavi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x010B78, 0x010B7F]
   ]
 });
-assert(
-  /^\p{Script=Inscriptional_Pahlavi}+$/u.test(matchSymbols),
-  "`\\p{Script=Inscriptional_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Inscriptional_Pahlavi}+$/u,
+  matchSymbols,
+  "\\p{Script=Inscriptional_Pahlavi}"
 );
-assert(
-  /^\p{Script=Phli}+$/u.test(matchSymbols),
-  "`\\p{Script=Phli}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Phli}+$/u,
+  matchSymbols,
+  "\\p{Script=Phli}"
 );
-assert(
-  /^\p{sc=Inscriptional_Pahlavi}+$/u.test(matchSymbols),
-  "`\\p{sc=Inscriptional_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Inscriptional_Pahlavi}+$/u,
+  matchSymbols,
+  "\\p{sc=Inscriptional_Pahlavi}"
 );
-assert(
-  /^\p{sc=Phli}+$/u.test(matchSymbols),
-  "`\\p{sc=Phli}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Phli}+$/u,
+  matchSymbols,
+  "\\p{sc=Phli}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x010B80, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Inscriptional_Pahlavi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Inscriptional_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Inscriptional_Pahlavi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Inscriptional_Pahlavi}"
 );
-assert(
-  /^\P{Script=Phli}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Phli}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Phli}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Phli}"
 );
-assert(
-  /^\P{sc=Inscriptional_Pahlavi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Inscriptional_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Inscriptional_Pahlavi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Inscriptional_Pahlavi}"
 );
-assert(
-  /^\P{sc=Phli}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Phli}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Phli}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Phli}"
 );

--- a/output/Script_-_Inscriptional_Parthian.js
+++ b/output/Script_-_Inscriptional_Parthian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x010B58, 0x010B5F]
   ]
 });
-assert(
-  /^\p{Script=Inscriptional_Parthian}+$/u.test(matchSymbols),
-  "`\\p{Script=Inscriptional_Parthian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Inscriptional_Parthian}+$/u,
+  matchSymbols,
+  "\\p{Script=Inscriptional_Parthian}"
 );
-assert(
-  /^\p{Script=Prti}+$/u.test(matchSymbols),
-  "`\\p{Script=Prti}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Prti}+$/u,
+  matchSymbols,
+  "\\p{Script=Prti}"
 );
-assert(
-  /^\p{sc=Inscriptional_Parthian}+$/u.test(matchSymbols),
-  "`\\p{sc=Inscriptional_Parthian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Inscriptional_Parthian}+$/u,
+  matchSymbols,
+  "\\p{sc=Inscriptional_Parthian}"
 );
-assert(
-  /^\p{sc=Prti}+$/u.test(matchSymbols),
-  "`\\p{sc=Prti}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Prti}+$/u,
+  matchSymbols,
+  "\\p{sc=Prti}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x010B60, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Inscriptional_Parthian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Inscriptional_Parthian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Inscriptional_Parthian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Inscriptional_Parthian}"
 );
-assert(
-  /^\P{Script=Prti}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Prti}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Prti}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Prti}"
 );
-assert(
-  /^\P{sc=Inscriptional_Parthian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Inscriptional_Parthian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Inscriptional_Parthian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Inscriptional_Parthian}"
 );
-assert(
-  /^\P{sc=Prti}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Prti}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Prti}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Prti}"
 );

--- a/output/Script_-_Javanese.js
+++ b/output/Script_-_Javanese.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00A9DE, 0x00A9DF]
   ]
 });
-assert(
-  /^\p{Script=Javanese}+$/u.test(matchSymbols),
-  "`\\p{Script=Javanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Javanese}+$/u,
+  matchSymbols,
+  "\\p{Script=Javanese}"
 );
-assert(
-  /^\p{Script=Java}+$/u.test(matchSymbols),
-  "`\\p{Script=Java}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Java}+$/u,
+  matchSymbols,
+  "\\p{Script=Java}"
 );
-assert(
-  /^\p{sc=Javanese}+$/u.test(matchSymbols),
-  "`\\p{sc=Javanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Javanese}+$/u,
+  matchSymbols,
+  "\\p{sc=Javanese}"
 );
-assert(
-  /^\p{sc=Java}+$/u.test(matchSymbols),
-  "`\\p{sc=Java}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Java}+$/u,
+  matchSymbols,
+  "\\p{sc=Java}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Javanese}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Javanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Javanese}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Javanese}"
 );
-assert(
-  /^\P{Script=Java}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Java}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Java}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Java}"
 );
-assert(
-  /^\P{sc=Javanese}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Javanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Javanese}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Javanese}"
 );
-assert(
-  /^\P{sc=Java}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Java}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Java}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Java}"
 );

--- a/output/Script_-_Kaithi.js
+++ b/output/Script_-_Kaithi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x011080, 0x0110C1]
   ]
 });
-assert(
-  /^\p{Script=Kaithi}+$/u.test(matchSymbols),
-  "`\\p{Script=Kaithi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Kaithi}+$/u,
+  matchSymbols,
+  "\\p{Script=Kaithi}"
 );
-assert(
-  /^\p{Script=Kthi}+$/u.test(matchSymbols),
-  "`\\p{Script=Kthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Kthi}+$/u,
+  matchSymbols,
+  "\\p{Script=Kthi}"
 );
-assert(
-  /^\p{sc=Kaithi}+$/u.test(matchSymbols),
-  "`\\p{sc=Kaithi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Kaithi}+$/u,
+  matchSymbols,
+  "\\p{sc=Kaithi}"
 );
-assert(
-  /^\p{sc=Kthi}+$/u.test(matchSymbols),
-  "`\\p{sc=Kthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Kthi}+$/u,
+  matchSymbols,
+  "\\p{sc=Kthi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x0110C2, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Kaithi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Kaithi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Kaithi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Kaithi}"
 );
-assert(
-  /^\P{Script=Kthi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Kthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Kthi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Kthi}"
 );
-assert(
-  /^\P{sc=Kaithi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Kaithi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Kaithi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Kaithi}"
 );
-assert(
-  /^\P{sc=Kthi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Kthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Kthi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Kthi}"
 );

--- a/output/Script_-_Kannada.js
+++ b/output/Script_-_Kannada.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -33,21 +33,25 @@ const matchSymbols = buildString({
     [0x000CF1, 0x000CF2]
   ]
 });
-assert(
-  /^\p{Script=Kannada}+$/u.test(matchSymbols),
-  "`\\p{Script=Kannada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Kannada}+$/u,
+  matchSymbols,
+  "\\p{Script=Kannada}"
 );
-assert(
-  /^\p{Script=Knda}+$/u.test(matchSymbols),
-  "`\\p{Script=Knda}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Knda}+$/u,
+  matchSymbols,
+  "\\p{Script=Knda}"
 );
-assert(
-  /^\p{sc=Kannada}+$/u.test(matchSymbols),
-  "`\\p{sc=Kannada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Kannada}+$/u,
+  matchSymbols,
+  "\\p{sc=Kannada}"
 );
-assert(
-  /^\p{sc=Knda}+$/u.test(matchSymbols),
-  "`\\p{sc=Knda}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Knda}+$/u,
+  matchSymbols,
+  "\\p{sc=Knda}"
 );
 
 const nonMatchSymbols = buildString({
@@ -73,19 +77,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Kannada}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Kannada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Kannada}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Kannada}"
 );
-assert(
-  /^\P{Script=Knda}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Knda}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Knda}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Knda}"
 );
-assert(
-  /^\P{sc=Kannada}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Kannada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Kannada}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Kannada}"
 );
-assert(
-  /^\P{sc=Knda}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Knda}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Knda}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Knda}"
 );

--- a/output/Script_-_Katakana.js
+++ b/output/Script_-_Katakana.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -27,21 +27,25 @@ const matchSymbols = buildString({
     [0x00FF71, 0x00FF9D]
   ]
 });
-assert(
-  /^\p{Script=Katakana}+$/u.test(matchSymbols),
-  "`\\p{Script=Katakana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Katakana}+$/u,
+  matchSymbols,
+  "\\p{Script=Katakana}"
 );
-assert(
-  /^\p{Script=Kana}+$/u.test(matchSymbols),
-  "`\\p{Script=Kana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Kana}+$/u,
+  matchSymbols,
+  "\\p{Script=Kana}"
 );
-assert(
-  /^\p{sc=Katakana}+$/u.test(matchSymbols),
-  "`\\p{sc=Katakana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Katakana}+$/u,
+  matchSymbols,
+  "\\p{sc=Katakana}"
 );
-assert(
-  /^\p{sc=Kana}+$/u.test(matchSymbols),
-  "`\\p{sc=Kana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Kana}+$/u,
+  matchSymbols,
+  "\\p{sc=Kana}"
 );
 
 const nonMatchSymbols = buildString({
@@ -61,19 +65,23 @@ const nonMatchSymbols = buildString({
     [0x01B001, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Katakana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Katakana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Katakana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Katakana}"
 );
-assert(
-  /^\P{Script=Kana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Kana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Kana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Kana}"
 );
-assert(
-  /^\P{sc=Katakana}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Katakana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Katakana}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Katakana}"
 );
-assert(
-  /^\P{sc=Kana}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Kana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Kana}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Kana}"
 );

--- a/output/Script_-_Kayah_Li.js
+++ b/output/Script_-_Kayah_Li.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00A900, 0x00A92D]
   ]
 });
-assert(
-  /^\p{Script=Kayah_Li}+$/u.test(matchSymbols),
-  "`\\p{Script=Kayah_Li}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Kayah_Li}+$/u,
+  matchSymbols,
+  "\\p{Script=Kayah_Li}"
 );
-assert(
-  /^\p{Script=Kali}+$/u.test(matchSymbols),
-  "`\\p{Script=Kali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Kali}+$/u,
+  matchSymbols,
+  "\\p{Script=Kali}"
 );
-assert(
-  /^\p{sc=Kayah_Li}+$/u.test(matchSymbols),
-  "`\\p{sc=Kayah_Li}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Kayah_Li}+$/u,
+  matchSymbols,
+  "\\p{sc=Kayah_Li}"
 );
-assert(
-  /^\p{sc=Kali}+$/u.test(matchSymbols),
-  "`\\p{sc=Kali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Kali}+$/u,
+  matchSymbols,
+  "\\p{sc=Kali}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Kayah_Li}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Kayah_Li}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Kayah_Li}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Kayah_Li}"
 );
-assert(
-  /^\P{Script=Kali}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Kali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Kali}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Kali}"
 );
-assert(
-  /^\P{sc=Kayah_Li}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Kayah_Li}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Kayah_Li}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Kayah_Li}"
 );
-assert(
-  /^\P{sc=Kali}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Kali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Kali}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Kali}"
 );

--- a/output/Script_-_Kharoshthi.js
+++ b/output/Script_-_Kharoshthi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -26,21 +26,25 @@ const matchSymbols = buildString({
     [0x010A50, 0x010A58]
   ]
 });
-assert(
-  /^\p{Script=Kharoshthi}+$/u.test(matchSymbols),
-  "`\\p{Script=Kharoshthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Kharoshthi}+$/u,
+  matchSymbols,
+  "\\p{Script=Kharoshthi}"
 );
-assert(
-  /^\p{Script=Khar}+$/u.test(matchSymbols),
-  "`\\p{Script=Khar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Khar}+$/u,
+  matchSymbols,
+  "\\p{Script=Khar}"
 );
-assert(
-  /^\p{sc=Kharoshthi}+$/u.test(matchSymbols),
-  "`\\p{sc=Kharoshthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Kharoshthi}+$/u,
+  matchSymbols,
+  "\\p{sc=Kharoshthi}"
 );
-assert(
-  /^\p{sc=Khar}+$/u.test(matchSymbols),
-  "`\\p{sc=Khar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Khar}+$/u,
+  matchSymbols,
+  "\\p{sc=Khar}"
 );
 
 const nonMatchSymbols = buildString({
@@ -60,19 +64,23 @@ const nonMatchSymbols = buildString({
     [0x010A59, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Kharoshthi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Kharoshthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Kharoshthi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Kharoshthi}"
 );
-assert(
-  /^\P{Script=Khar}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Khar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Khar}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Khar}"
 );
-assert(
-  /^\P{sc=Kharoshthi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Kharoshthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Kharoshthi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Kharoshthi}"
 );
-assert(
-  /^\P{sc=Khar}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Khar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Khar}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Khar}"
 );

--- a/output/Script_-_Khmer.js
+++ b/output/Script_-_Khmer.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x0019E0, 0x0019FF]
   ]
 });
-assert(
-  /^\p{Script=Khmer}+$/u.test(matchSymbols),
-  "`\\p{Script=Khmer}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Khmer}+$/u,
+  matchSymbols,
+  "\\p{Script=Khmer}"
 );
-assert(
-  /^\p{Script=Khmr}+$/u.test(matchSymbols),
-  "`\\p{Script=Khmr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Khmr}+$/u,
+  matchSymbols,
+  "\\p{Script=Khmr}"
 );
-assert(
-  /^\p{sc=Khmer}+$/u.test(matchSymbols),
-  "`\\p{sc=Khmer}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Khmer}+$/u,
+  matchSymbols,
+  "\\p{sc=Khmer}"
 );
-assert(
-  /^\p{sc=Khmr}+$/u.test(matchSymbols),
-  "`\\p{sc=Khmr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Khmr}+$/u,
+  matchSymbols,
+  "\\p{sc=Khmr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Khmer}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Khmer}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Khmer}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Khmer}"
 );
-assert(
-  /^\P{Script=Khmr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Khmr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Khmr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Khmr}"
 );
-assert(
-  /^\P{sc=Khmer}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Khmer}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Khmer}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Khmer}"
 );
-assert(
-  /^\P{sc=Khmr}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Khmr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Khmr}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Khmr}"
 );

--- a/output/Script_-_Khojki.js
+++ b/output/Script_-_Khojki.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x011213, 0x01123E]
   ]
 });
-assert(
-  /^\p{Script=Khojki}+$/u.test(matchSymbols),
-  "`\\p{Script=Khojki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Khojki}+$/u,
+  matchSymbols,
+  "\\p{Script=Khojki}"
 );
-assert(
-  /^\p{Script=Khoj}+$/u.test(matchSymbols),
-  "`\\p{Script=Khoj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Khoj}+$/u,
+  matchSymbols,
+  "\\p{Script=Khoj}"
 );
-assert(
-  /^\p{sc=Khojki}+$/u.test(matchSymbols),
-  "`\\p{sc=Khojki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Khojki}+$/u,
+  matchSymbols,
+  "\\p{sc=Khojki}"
 );
-assert(
-  /^\p{sc=Khoj}+$/u.test(matchSymbols),
-  "`\\p{sc=Khoj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Khoj}+$/u,
+  matchSymbols,
+  "\\p{sc=Khoj}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x01123F, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Khojki}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Khojki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Khojki}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Khojki}"
 );
-assert(
-  /^\P{Script=Khoj}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Khoj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Khoj}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Khoj}"
 );
-assert(
-  /^\P{sc=Khojki}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Khojki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Khojki}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Khojki}"
 );
-assert(
-  /^\P{sc=Khoj}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Khoj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Khoj}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Khoj}"
 );

--- a/output/Script_-_Khudawadi.js
+++ b/output/Script_-_Khudawadi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0112F0, 0x0112F9]
   ]
 });
-assert(
-  /^\p{Script=Khudawadi}+$/u.test(matchSymbols),
-  "`\\p{Script=Khudawadi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Khudawadi}+$/u,
+  matchSymbols,
+  "\\p{Script=Khudawadi}"
 );
-assert(
-  /^\p{Script=Sind}+$/u.test(matchSymbols),
-  "`\\p{Script=Sind}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sind}+$/u,
+  matchSymbols,
+  "\\p{Script=Sind}"
 );
-assert(
-  /^\p{sc=Khudawadi}+$/u.test(matchSymbols),
-  "`\\p{sc=Khudawadi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Khudawadi}+$/u,
+  matchSymbols,
+  "\\p{sc=Khudawadi}"
 );
-assert(
-  /^\p{sc=Sind}+$/u.test(matchSymbols),
-  "`\\p{sc=Sind}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sind}+$/u,
+  matchSymbols,
+  "\\p{sc=Sind}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0112FA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Khudawadi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Khudawadi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Khudawadi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Khudawadi}"
 );
-assert(
-  /^\P{Script=Sind}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sind}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sind}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sind}"
 );
-assert(
-  /^\P{sc=Khudawadi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Khudawadi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Khudawadi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Khudawadi}"
 );
-assert(
-  /^\P{sc=Sind}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sind}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sind}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sind}"
 );

--- a/output/Script_-_Lao.js
+++ b/output/Script_-_Lao.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -37,21 +37,25 @@ const matchSymbols = buildString({
     [0x000EDC, 0x000EDF]
   ]
 });
-assert(
-  /^\p{Script=Lao}+$/u.test(matchSymbols),
-  "`\\p{Script=Lao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lao}+$/u,
+  matchSymbols,
+  "\\p{Script=Lao}"
 );
-assert(
-  /^\p{Script=Laoo}+$/u.test(matchSymbols),
-  "`\\p{Script=Laoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Laoo}+$/u,
+  matchSymbols,
+  "\\p{Script=Laoo}"
 );
-assert(
-  /^\p{sc=Lao}+$/u.test(matchSymbols),
-  "`\\p{sc=Lao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lao}+$/u,
+  matchSymbols,
+  "\\p{sc=Lao}"
 );
-assert(
-  /^\p{sc=Laoo}+$/u.test(matchSymbols),
-  "`\\p{sc=Laoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Laoo}+$/u,
+  matchSymbols,
+  "\\p{sc=Laoo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -81,19 +85,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Lao}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lao}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lao}"
 );
-assert(
-  /^\P{Script=Laoo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Laoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Laoo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Laoo}"
 );
-assert(
-  /^\P{sc=Lao}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lao}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lao}"
 );
-assert(
-  /^\P{sc=Laoo}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Laoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Laoo}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Laoo}"
 );

--- a/output/Script_-_Latin.js
+++ b/output/Script_-_Latin.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -50,21 +50,25 @@ const matchSymbols = buildString({
     [0x00FF41, 0x00FF5A]
   ]
 });
-assert(
-  /^\p{Script=Latin}+$/u.test(matchSymbols),
-  "`\\p{Script=Latin}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Latin}+$/u,
+  matchSymbols,
+  "\\p{Script=Latin}"
 );
-assert(
-  /^\p{Script=Latn}+$/u.test(matchSymbols),
-  "`\\p{Script=Latn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Latn}+$/u,
+  matchSymbols,
+  "\\p{Script=Latn}"
 );
-assert(
-  /^\p{sc=Latin}+$/u.test(matchSymbols),
-  "`\\p{sc=Latin}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Latin}+$/u,
+  matchSymbols,
+  "\\p{sc=Latin}"
 );
-assert(
-  /^\p{sc=Latn}+$/u.test(matchSymbols),
-  "`\\p{sc=Latn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Latn}+$/u,
+  matchSymbols,
+  "\\p{sc=Latn}"
 );
 
 const nonMatchSymbols = buildString({
@@ -107,19 +111,23 @@ const nonMatchSymbols = buildString({
     [0x00FF5B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Latin}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Latin}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Latin}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Latin}"
 );
-assert(
-  /^\P{Script=Latn}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Latn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Latn}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Latn}"
 );
-assert(
-  /^\P{sc=Latin}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Latin}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Latin}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Latin}"
 );
-assert(
-  /^\P{sc=Latn}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Latn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Latn}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Latn}"
 );

--- a/output/Script_-_Lepcha.js
+++ b/output/Script_-_Lepcha.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x001C4D, 0x001C4F]
   ]
 });
-assert(
-  /^\p{Script=Lepcha}+$/u.test(matchSymbols),
-  "`\\p{Script=Lepcha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lepcha}+$/u,
+  matchSymbols,
+  "\\p{Script=Lepcha}"
 );
-assert(
-  /^\p{Script=Lepc}+$/u.test(matchSymbols),
-  "`\\p{Script=Lepc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lepc}+$/u,
+  matchSymbols,
+  "\\p{Script=Lepc}"
 );
-assert(
-  /^\p{sc=Lepcha}+$/u.test(matchSymbols),
-  "`\\p{sc=Lepcha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lepcha}+$/u,
+  matchSymbols,
+  "\\p{sc=Lepcha}"
 );
-assert(
-  /^\p{sc=Lepc}+$/u.test(matchSymbols),
-  "`\\p{sc=Lepc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lepc}+$/u,
+  matchSymbols,
+  "\\p{sc=Lepc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Lepcha}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lepcha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lepcha}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lepcha}"
 );
-assert(
-  /^\P{Script=Lepc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lepc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lepc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lepc}"
 );
-assert(
-  /^\P{sc=Lepcha}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lepcha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lepcha}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lepcha}"
 );
-assert(
-  /^\P{sc=Lepc}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lepc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lepc}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lepc}"
 );

--- a/output/Script_-_Limbu.js
+++ b/output/Script_-_Limbu.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -24,21 +24,25 @@ const matchSymbols = buildString({
     [0x001944, 0x00194F]
   ]
 });
-assert(
-  /^\p{Script=Limbu}+$/u.test(matchSymbols),
-  "`\\p{Script=Limbu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Limbu}+$/u,
+  matchSymbols,
+  "\\p{Script=Limbu}"
 );
-assert(
-  /^\p{Script=Limb}+$/u.test(matchSymbols),
-  "`\\p{Script=Limb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Limb}+$/u,
+  matchSymbols,
+  "\\p{Script=Limb}"
 );
-assert(
-  /^\p{sc=Limbu}+$/u.test(matchSymbols),
-  "`\\p{sc=Limbu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Limbu}+$/u,
+  matchSymbols,
+  "\\p{sc=Limbu}"
 );
-assert(
-  /^\p{sc=Limb}+$/u.test(matchSymbols),
-  "`\\p{sc=Limb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Limb}+$/u,
+  matchSymbols,
+  "\\p{sc=Limb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -55,19 +59,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Limbu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Limbu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Limbu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Limbu}"
 );
-assert(
-  /^\P{Script=Limb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Limb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Limb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Limb}"
 );
-assert(
-  /^\P{sc=Limbu}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Limbu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Limbu}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Limbu}"
 );
-assert(
-  /^\P{sc=Limb}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Limb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Limb}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Limb}"
 );

--- a/output/Script_-_Linear_A.js
+++ b/output/Script_-_Linear_A.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010760, 0x010767]
   ]
 });
-assert(
-  /^\p{Script=Linear_A}+$/u.test(matchSymbols),
-  "`\\p{Script=Linear_A}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Linear_A}+$/u,
+  matchSymbols,
+  "\\p{Script=Linear_A}"
 );
-assert(
-  /^\p{Script=Lina}+$/u.test(matchSymbols),
-  "`\\p{Script=Lina}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lina}+$/u,
+  matchSymbols,
+  "\\p{Script=Lina}"
 );
-assert(
-  /^\p{sc=Linear_A}+$/u.test(matchSymbols),
-  "`\\p{sc=Linear_A}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Linear_A}+$/u,
+  matchSymbols,
+  "\\p{sc=Linear_A}"
 );
-assert(
-  /^\p{sc=Lina}+$/u.test(matchSymbols),
-  "`\\p{sc=Lina}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lina}+$/u,
+  matchSymbols,
+  "\\p{sc=Lina}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x010768, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Linear_A}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Linear_A}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Linear_A}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Linear_A}"
 );
-assert(
-  /^\P{Script=Lina}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lina}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lina}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lina}"
 );
-assert(
-  /^\P{sc=Linear_A}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Linear_A}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Linear_A}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Linear_A}"
 );
-assert(
-  /^\P{sc=Lina}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lina}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lina}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lina}"
 );

--- a/output/Script_-_Linear_B.js
+++ b/output/Script_-_Linear_B.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,21 +25,25 @@ const matchSymbols = buildString({
     [0x010080, 0x0100FA]
   ]
 });
-assert(
-  /^\p{Script=Linear_B}+$/u.test(matchSymbols),
-  "`\\p{Script=Linear_B}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Linear_B}+$/u,
+  matchSymbols,
+  "\\p{Script=Linear_B}"
 );
-assert(
-  /^\p{Script=Linb}+$/u.test(matchSymbols),
-  "`\\p{Script=Linb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Linb}+$/u,
+  matchSymbols,
+  "\\p{Script=Linb}"
 );
-assert(
-  /^\p{sc=Linear_B}+$/u.test(matchSymbols),
-  "`\\p{sc=Linear_B}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Linear_B}+$/u,
+  matchSymbols,
+  "\\p{sc=Linear_B}"
 );
-assert(
-  /^\p{sc=Linb}+$/u.test(matchSymbols),
-  "`\\p{sc=Linb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Linb}+$/u,
+  matchSymbols,
+  "\\p{sc=Linb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -58,19 +62,23 @@ const nonMatchSymbols = buildString({
     [0x0100FB, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Linear_B}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Linear_B}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Linear_B}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Linear_B}"
 );
-assert(
-  /^\P{Script=Linb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Linb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Linb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Linb}"
 );
-assert(
-  /^\P{sc=Linear_B}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Linear_B}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Linear_B}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Linear_B}"
 );
-assert(
-  /^\P{sc=Linb}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Linb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Linb}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Linb}"
 );

--- a/output/Script_-_Lisu.js
+++ b/output/Script_-_Lisu.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x00A4D0, 0x00A4FF]
   ]
 });
-assert(
-  /^\p{Script=Lisu}+$/u.test(matchSymbols),
-  "`\\p{Script=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lisu}+$/u,
+  matchSymbols,
+  "\\p{Script=Lisu}"
 );
-assert(
-  /^\p{Script=Lisu}+$/u.test(matchSymbols),
-  "`\\p{Script=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lisu}+$/u,
+  matchSymbols,
+  "\\p{Script=Lisu}"
 );
-assert(
-  /^\p{sc=Lisu}+$/u.test(matchSymbols),
-  "`\\p{sc=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lisu}+$/u,
+  matchSymbols,
+  "\\p{sc=Lisu}"
 );
-assert(
-  /^\p{sc=Lisu}+$/u.test(matchSymbols),
-  "`\\p{sc=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lisu}+$/u,
+  matchSymbols,
+  "\\p{sc=Lisu}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Lisu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lisu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lisu}"
 );
-assert(
-  /^\P{Script=Lisu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lisu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lisu}"
 );
-assert(
-  /^\P{sc=Lisu}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lisu}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lisu}"
 );
-assert(
-  /^\P{sc=Lisu}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lisu}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lisu}"
 );

--- a/output/Script_-_Lycian.js
+++ b/output/Script_-_Lycian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010280, 0x01029C]
   ]
 });
-assert(
-  /^\p{Script=Lycian}+$/u.test(matchSymbols),
-  "`\\p{Script=Lycian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lycian}+$/u,
+  matchSymbols,
+  "\\p{Script=Lycian}"
 );
-assert(
-  /^\p{Script=Lyci}+$/u.test(matchSymbols),
-  "`\\p{Script=Lyci}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lyci}+$/u,
+  matchSymbols,
+  "\\p{Script=Lyci}"
 );
-assert(
-  /^\p{sc=Lycian}+$/u.test(matchSymbols),
-  "`\\p{sc=Lycian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lycian}+$/u,
+  matchSymbols,
+  "\\p{sc=Lycian}"
 );
-assert(
-  /^\p{sc=Lyci}+$/u.test(matchSymbols),
-  "`\\p{sc=Lyci}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lyci}+$/u,
+  matchSymbols,
+  "\\p{sc=Lyci}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x01029D, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Lycian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lycian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lycian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lycian}"
 );
-assert(
-  /^\P{Script=Lyci}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lyci}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lyci}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lyci}"
 );
-assert(
-  /^\P{sc=Lycian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lycian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lycian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lycian}"
 );
-assert(
-  /^\P{sc=Lyci}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lyci}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lyci}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lyci}"
 );

--- a/output/Script_-_Lydian.js
+++ b/output/Script_-_Lydian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010920, 0x010939]
   ]
 });
-assert(
-  /^\p{Script=Lydian}+$/u.test(matchSymbols),
-  "`\\p{Script=Lydian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lydian}+$/u,
+  matchSymbols,
+  "\\p{Script=Lydian}"
 );
-assert(
-  /^\p{Script=Lydi}+$/u.test(matchSymbols),
-  "`\\p{Script=Lydi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lydi}+$/u,
+  matchSymbols,
+  "\\p{Script=Lydi}"
 );
-assert(
-  /^\p{sc=Lydian}+$/u.test(matchSymbols),
-  "`\\p{sc=Lydian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lydian}+$/u,
+  matchSymbols,
+  "\\p{sc=Lydian}"
 );
-assert(
-  /^\p{sc=Lydi}+$/u.test(matchSymbols),
-  "`\\p{sc=Lydi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lydi}+$/u,
+  matchSymbols,
+  "\\p{sc=Lydi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x010940, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Lydian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lydian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lydian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lydian}"
 );
-assert(
-  /^\P{Script=Lydi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lydi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lydi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lydi}"
 );
-assert(
-  /^\P{sc=Lydian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lydian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lydian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lydian}"
 );
-assert(
-  /^\P{sc=Lydi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lydi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lydi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lydi}"
 );

--- a/output/Script_-_Mahajani.js
+++ b/output/Script_-_Mahajani.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x011150, 0x011176]
   ]
 });
-assert(
-  /^\p{Script=Mahajani}+$/u.test(matchSymbols),
-  "`\\p{Script=Mahajani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mahajani}+$/u,
+  matchSymbols,
+  "\\p{Script=Mahajani}"
 );
-assert(
-  /^\p{Script=Mahj}+$/u.test(matchSymbols),
-  "`\\p{Script=Mahj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mahj}+$/u,
+  matchSymbols,
+  "\\p{Script=Mahj}"
 );
-assert(
-  /^\p{sc=Mahajani}+$/u.test(matchSymbols),
-  "`\\p{sc=Mahajani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mahajani}+$/u,
+  matchSymbols,
+  "\\p{sc=Mahajani}"
 );
-assert(
-  /^\p{sc=Mahj}+$/u.test(matchSymbols),
-  "`\\p{sc=Mahj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mahj}+$/u,
+  matchSymbols,
+  "\\p{sc=Mahj}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x011177, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Mahajani}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mahajani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mahajani}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mahajani}"
 );
-assert(
-  /^\P{Script=Mahj}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mahj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mahj}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mahj}"
 );
-assert(
-  /^\P{sc=Mahajani}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mahajani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mahajani}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mahajani}"
 );
-assert(
-  /^\P{sc=Mahj}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mahj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mahj}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mahj}"
 );

--- a/output/Script_-_Malayalam.js
+++ b/output/Script_-_Malayalam.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -27,21 +27,25 @@ const matchSymbols = buildString({
     [0x000D66, 0x000D7F]
   ]
 });
-assert(
-  /^\p{Script=Malayalam}+$/u.test(matchSymbols),
-  "`\\p{Script=Malayalam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Malayalam}+$/u,
+  matchSymbols,
+  "\\p{Script=Malayalam}"
 );
-assert(
-  /^\p{Script=Mlym}+$/u.test(matchSymbols),
-  "`\\p{Script=Mlym}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mlym}+$/u,
+  matchSymbols,
+  "\\p{Script=Mlym}"
 );
-assert(
-  /^\p{sc=Malayalam}+$/u.test(matchSymbols),
-  "`\\p{sc=Malayalam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Malayalam}+$/u,
+  matchSymbols,
+  "\\p{sc=Malayalam}"
 );
-assert(
-  /^\p{sc=Mlym}+$/u.test(matchSymbols),
-  "`\\p{sc=Mlym}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mlym}+$/u,
+  matchSymbols,
+  "\\p{sc=Mlym}"
 );
 
 const nonMatchSymbols = buildString({
@@ -62,19 +66,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Malayalam}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Malayalam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Malayalam}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Malayalam}"
 );
-assert(
-  /^\P{Script=Mlym}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mlym}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mlym}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mlym}"
 );
-assert(
-  /^\P{sc=Malayalam}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Malayalam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Malayalam}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Malayalam}"
 );
-assert(
-  /^\P{sc=Mlym}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mlym}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mlym}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mlym}"
 );

--- a/output/Script_-_Mandaic.js
+++ b/output/Script_-_Mandaic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x000840, 0x00085B]
   ]
 });
-assert(
-  /^\p{Script=Mandaic}+$/u.test(matchSymbols),
-  "`\\p{Script=Mandaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mandaic}+$/u,
+  matchSymbols,
+  "\\p{Script=Mandaic}"
 );
-assert(
-  /^\p{Script=Mand}+$/u.test(matchSymbols),
-  "`\\p{Script=Mand}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mand}+$/u,
+  matchSymbols,
+  "\\p{Script=Mand}"
 );
-assert(
-  /^\p{sc=Mandaic}+$/u.test(matchSymbols),
-  "`\\p{sc=Mandaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mandaic}+$/u,
+  matchSymbols,
+  "\\p{sc=Mandaic}"
 );
-assert(
-  /^\p{sc=Mand}+$/u.test(matchSymbols),
-  "`\\p{sc=Mand}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mand}+$/u,
+  matchSymbols,
+  "\\p{sc=Mand}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Mandaic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mandaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mandaic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mandaic}"
 );
-assert(
-  /^\P{Script=Mand}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mand}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mand}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mand}"
 );
-assert(
-  /^\P{sc=Mandaic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mandaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mandaic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mandaic}"
 );
-assert(
-  /^\P{sc=Mand}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mand}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mand}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mand}"
 );

--- a/output/Script_-_Manichaean.js
+++ b/output/Script_-_Manichaean.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x010AEB, 0x010AF6]
   ]
 });
-assert(
-  /^\p{Script=Manichaean}+$/u.test(matchSymbols),
-  "`\\p{Script=Manichaean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Manichaean}+$/u,
+  matchSymbols,
+  "\\p{Script=Manichaean}"
 );
-assert(
-  /^\p{Script=Mani}+$/u.test(matchSymbols),
-  "`\\p{Script=Mani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mani}+$/u,
+  matchSymbols,
+  "\\p{Script=Mani}"
 );
-assert(
-  /^\p{sc=Manichaean}+$/u.test(matchSymbols),
-  "`\\p{sc=Manichaean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Manichaean}+$/u,
+  matchSymbols,
+  "\\p{sc=Manichaean}"
 );
-assert(
-  /^\p{sc=Mani}+$/u.test(matchSymbols),
-  "`\\p{sc=Mani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mani}+$/u,
+  matchSymbols,
+  "\\p{sc=Mani}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x010AF7, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Manichaean}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Manichaean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Manichaean}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Manichaean}"
 );
-assert(
-  /^\P{Script=Mani}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mani}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mani}"
 );
-assert(
-  /^\P{sc=Manichaean}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Manichaean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Manichaean}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Manichaean}"
 );
-assert(
-  /^\P{sc=Mani}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mani}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mani}"
 );

--- a/output/Script_-_Marchen.js
+++ b/output/Script_-_Marchen.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x011CA9, 0x011CB6]
   ]
 });
-assert(
-  /^\p{Script=Marchen}+$/u.test(matchSymbols),
-  "`\\p{Script=Marchen}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Marchen}+$/u,
+  matchSymbols,
+  "\\p{Script=Marchen}"
 );
-assert(
-  /^\p{Script=Marc}+$/u.test(matchSymbols),
-  "`\\p{Script=Marc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Marc}+$/u,
+  matchSymbols,
+  "\\p{Script=Marc}"
 );
-assert(
-  /^\p{sc=Marchen}+$/u.test(matchSymbols),
-  "`\\p{sc=Marchen}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Marchen}+$/u,
+  matchSymbols,
+  "\\p{sc=Marchen}"
 );
-assert(
-  /^\p{sc=Marc}+$/u.test(matchSymbols),
-  "`\\p{sc=Marc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Marc}+$/u,
+  matchSymbols,
+  "\\p{sc=Marc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x011CB7, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Marchen}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Marchen}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Marchen}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Marchen}"
 );
-assert(
-  /^\P{Script=Marc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Marc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Marc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Marc}"
 );
-assert(
-  /^\P{sc=Marchen}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Marchen}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Marchen}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Marchen}"
 );
-assert(
-  /^\P{sc=Marc}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Marc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Marc}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Marc}"
 );

--- a/output/Script_-_Meetei_Mayek.js
+++ b/output/Script_-_Meetei_Mayek.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00ABF0, 0x00ABF9]
   ]
 });
-assert(
-  /^\p{Script=Meetei_Mayek}+$/u.test(matchSymbols),
-  "`\\p{Script=Meetei_Mayek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Meetei_Mayek}+$/u,
+  matchSymbols,
+  "\\p{Script=Meetei_Mayek}"
 );
-assert(
-  /^\p{Script=Mtei}+$/u.test(matchSymbols),
-  "`\\p{Script=Mtei}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mtei}+$/u,
+  matchSymbols,
+  "\\p{Script=Mtei}"
 );
-assert(
-  /^\p{sc=Meetei_Mayek}+$/u.test(matchSymbols),
-  "`\\p{sc=Meetei_Mayek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Meetei_Mayek}+$/u,
+  matchSymbols,
+  "\\p{sc=Meetei_Mayek}"
 );
-assert(
-  /^\p{sc=Mtei}+$/u.test(matchSymbols),
-  "`\\p{sc=Mtei}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mtei}+$/u,
+  matchSymbols,
+  "\\p{sc=Mtei}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Meetei_Mayek}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Meetei_Mayek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Meetei_Mayek}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Meetei_Mayek}"
 );
-assert(
-  /^\P{Script=Mtei}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mtei}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mtei}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mtei}"
 );
-assert(
-  /^\P{sc=Meetei_Mayek}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Meetei_Mayek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Meetei_Mayek}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Meetei_Mayek}"
 );
-assert(
-  /^\P{sc=Mtei}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mtei}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mtei}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mtei}"
 );

--- a/output/Script_-_Mende_Kikakui.js
+++ b/output/Script_-_Mende_Kikakui.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x01E8C7, 0x01E8D6]
   ]
 });
-assert(
-  /^\p{Script=Mende_Kikakui}+$/u.test(matchSymbols),
-  "`\\p{Script=Mende_Kikakui}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mende_Kikakui}+$/u,
+  matchSymbols,
+  "\\p{Script=Mende_Kikakui}"
 );
-assert(
-  /^\p{Script=Mend}+$/u.test(matchSymbols),
-  "`\\p{Script=Mend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mend}+$/u,
+  matchSymbols,
+  "\\p{Script=Mend}"
 );
-assert(
-  /^\p{sc=Mende_Kikakui}+$/u.test(matchSymbols),
-  "`\\p{sc=Mende_Kikakui}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mende_Kikakui}+$/u,
+  matchSymbols,
+  "\\p{sc=Mende_Kikakui}"
 );
-assert(
-  /^\p{sc=Mend}+$/u.test(matchSymbols),
-  "`\\p{sc=Mend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mend}+$/u,
+  matchSymbols,
+  "\\p{sc=Mend}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x01E8D7, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Mende_Kikakui}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mende_Kikakui}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mende_Kikakui}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mende_Kikakui}"
 );
-assert(
-  /^\P{Script=Mend}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mend}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mend}"
 );
-assert(
-  /^\P{sc=Mende_Kikakui}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mende_Kikakui}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mende_Kikakui}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mende_Kikakui}"
 );
-assert(
-  /^\P{sc=Mend}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mend}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mend}"
 );

--- a/output/Script_-_Meroitic_Cursive.js
+++ b/output/Script_-_Meroitic_Cursive.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x0109D2, 0x0109FF]
   ]
 });
-assert(
-  /^\p{Script=Meroitic_Cursive}+$/u.test(matchSymbols),
-  "`\\p{Script=Meroitic_Cursive}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Meroitic_Cursive}+$/u,
+  matchSymbols,
+  "\\p{Script=Meroitic_Cursive}"
 );
-assert(
-  /^\p{Script=Merc}+$/u.test(matchSymbols),
-  "`\\p{Script=Merc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Merc}+$/u,
+  matchSymbols,
+  "\\p{Script=Merc}"
 );
-assert(
-  /^\p{sc=Meroitic_Cursive}+$/u.test(matchSymbols),
-  "`\\p{sc=Meroitic_Cursive}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Meroitic_Cursive}+$/u,
+  matchSymbols,
+  "\\p{sc=Meroitic_Cursive}"
 );
-assert(
-  /^\p{sc=Merc}+$/u.test(matchSymbols),
-  "`\\p{sc=Merc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Merc}+$/u,
+  matchSymbols,
+  "\\p{sc=Merc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x010A00, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Meroitic_Cursive}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Meroitic_Cursive}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Meroitic_Cursive}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Meroitic_Cursive}"
 );
-assert(
-  /^\P{Script=Merc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Merc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Merc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Merc}"
 );
-assert(
-  /^\P{sc=Meroitic_Cursive}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Meroitic_Cursive}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Meroitic_Cursive}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Meroitic_Cursive}"
 );
-assert(
-  /^\P{sc=Merc}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Merc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Merc}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Merc}"
 );

--- a/output/Script_-_Meroitic_Hieroglyphs.js
+++ b/output/Script_-_Meroitic_Hieroglyphs.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010980, 0x01099F]
   ]
 });
-assert(
-  /^\p{Script=Meroitic_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{Script=Meroitic_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Meroitic_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{Script=Meroitic_Hieroglyphs}"
 );
-assert(
-  /^\p{Script=Mero}+$/u.test(matchSymbols),
-  "`\\p{Script=Mero}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mero}+$/u,
+  matchSymbols,
+  "\\p{Script=Mero}"
 );
-assert(
-  /^\p{sc=Meroitic_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{sc=Meroitic_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Meroitic_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{sc=Meroitic_Hieroglyphs}"
 );
-assert(
-  /^\p{sc=Mero}+$/u.test(matchSymbols),
-  "`\\p{sc=Mero}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mero}+$/u,
+  matchSymbols,
+  "\\p{sc=Mero}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x0109A0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Meroitic_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Meroitic_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Meroitic_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Meroitic_Hieroglyphs}"
 );
-assert(
-  /^\P{Script=Mero}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mero}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mero}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mero}"
 );
-assert(
-  /^\P{sc=Meroitic_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Meroitic_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Meroitic_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Meroitic_Hieroglyphs}"
 );
-assert(
-  /^\P{sc=Mero}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mero}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mero}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mero}"
 );

--- a/output/Script_-_Miao.js
+++ b/output/Script_-_Miao.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x016F8F, 0x016F9F]
   ]
 });
-assert(
-  /^\p{Script=Miao}+$/u.test(matchSymbols),
-  "`\\p{Script=Miao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Miao}+$/u,
+  matchSymbols,
+  "\\p{Script=Miao}"
 );
-assert(
-  /^\p{Script=Plrd}+$/u.test(matchSymbols),
-  "`\\p{Script=Plrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Plrd}+$/u,
+  matchSymbols,
+  "\\p{Script=Plrd}"
 );
-assert(
-  /^\p{sc=Miao}+$/u.test(matchSymbols),
-  "`\\p{sc=Miao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Miao}+$/u,
+  matchSymbols,
+  "\\p{sc=Miao}"
 );
-assert(
-  /^\p{sc=Plrd}+$/u.test(matchSymbols),
-  "`\\p{sc=Plrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Plrd}+$/u,
+  matchSymbols,
+  "\\p{sc=Plrd}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x016FA0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Miao}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Miao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Miao}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Miao}"
 );
-assert(
-  /^\P{Script=Plrd}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Plrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Plrd}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Plrd}"
 );
-assert(
-  /^\P{sc=Miao}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Miao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Miao}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Miao}"
 );
-assert(
-  /^\P{sc=Plrd}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Plrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Plrd}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Plrd}"
 );

--- a/output/Script_-_Modi.js
+++ b/output/Script_-_Modi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x011650, 0x011659]
   ]
 });
-assert(
-  /^\p{Script=Modi}+$/u.test(matchSymbols),
-  "`\\p{Script=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Modi}+$/u,
+  matchSymbols,
+  "\\p{Script=Modi}"
 );
-assert(
-  /^\p{Script=Modi}+$/u.test(matchSymbols),
-  "`\\p{Script=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Modi}+$/u,
+  matchSymbols,
+  "\\p{Script=Modi}"
 );
-assert(
-  /^\p{sc=Modi}+$/u.test(matchSymbols),
-  "`\\p{sc=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Modi}+$/u,
+  matchSymbols,
+  "\\p{sc=Modi}"
 );
-assert(
-  /^\p{sc=Modi}+$/u.test(matchSymbols),
-  "`\\p{sc=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Modi}+$/u,
+  matchSymbols,
+  "\\p{sc=Modi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x01165A, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Modi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Modi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Modi}"
 );
-assert(
-  /^\P{Script=Modi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Modi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Modi}"
 );
-assert(
-  /^\P{sc=Modi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Modi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Modi}"
 );
-assert(
-  /^\P{sc=Modi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Modi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Modi}"
 );

--- a/output/Script_-_Mongolian.js
+++ b/output/Script_-_Mongolian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -26,21 +26,25 @@ const matchSymbols = buildString({
     [0x011660, 0x01166C]
   ]
 });
-assert(
-  /^\p{Script=Mongolian}+$/u.test(matchSymbols),
-  "`\\p{Script=Mongolian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mongolian}+$/u,
+  matchSymbols,
+  "\\p{Script=Mongolian}"
 );
-assert(
-  /^\p{Script=Mong}+$/u.test(matchSymbols),
-  "`\\p{Script=Mong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mong}+$/u,
+  matchSymbols,
+  "\\p{Script=Mong}"
 );
-assert(
-  /^\p{sc=Mongolian}+$/u.test(matchSymbols),
-  "`\\p{sc=Mongolian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mongolian}+$/u,
+  matchSymbols,
+  "\\p{sc=Mongolian}"
 );
-assert(
-  /^\p{sc=Mong}+$/u.test(matchSymbols),
-  "`\\p{sc=Mong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mong}+$/u,
+  matchSymbols,
+  "\\p{sc=Mong}"
 );
 
 const nonMatchSymbols = buildString({
@@ -59,19 +63,23 @@ const nonMatchSymbols = buildString({
     [0x01166D, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Mongolian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mongolian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mongolian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mongolian}"
 );
-assert(
-  /^\P{Script=Mong}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mong}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mong}"
 );
-assert(
-  /^\P{sc=Mongolian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mongolian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mongolian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mongolian}"
 );
-assert(
-  /^\P{sc=Mong}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mong}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mong}"
 );

--- a/output/Script_-_Mro.js
+++ b/output/Script_-_Mro.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x016A6E, 0x016A6F]
   ]
 });
-assert(
-  /^\p{Script=Mro}+$/u.test(matchSymbols),
-  "`\\p{Script=Mro}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mro}+$/u,
+  matchSymbols,
+  "\\p{Script=Mro}"
 );
-assert(
-  /^\p{Script=Mroo}+$/u.test(matchSymbols),
-  "`\\p{Script=Mroo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mroo}+$/u,
+  matchSymbols,
+  "\\p{Script=Mroo}"
 );
-assert(
-  /^\p{sc=Mro}+$/u.test(matchSymbols),
-  "`\\p{sc=Mro}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mro}+$/u,
+  matchSymbols,
+  "\\p{sc=Mro}"
 );
-assert(
-  /^\p{sc=Mroo}+$/u.test(matchSymbols),
-  "`\\p{sc=Mroo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mroo}+$/u,
+  matchSymbols,
+  "\\p{sc=Mroo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x016A70, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Mro}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mro}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mro}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mro}"
 );
-assert(
-  /^\P{Script=Mroo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mroo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mroo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mroo}"
 );
-assert(
-  /^\P{sc=Mro}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mro}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mro}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mro}"
 );
-assert(
-  /^\P{sc=Mroo}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mroo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mroo}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mroo}"
 );

--- a/output/Script_-_Multani.js
+++ b/output/Script_-_Multani.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -24,21 +24,25 @@ const matchSymbols = buildString({
     [0x01129F, 0x0112A9]
   ]
 });
-assert(
-  /^\p{Script=Multani}+$/u.test(matchSymbols),
-  "`\\p{Script=Multani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Multani}+$/u,
+  matchSymbols,
+  "\\p{Script=Multani}"
 );
-assert(
-  /^\p{Script=Mult}+$/u.test(matchSymbols),
-  "`\\p{Script=Mult}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mult}+$/u,
+  matchSymbols,
+  "\\p{Script=Mult}"
 );
-assert(
-  /^\p{sc=Multani}+$/u.test(matchSymbols),
-  "`\\p{sc=Multani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Multani}+$/u,
+  matchSymbols,
+  "\\p{sc=Multani}"
 );
-assert(
-  /^\p{sc=Mult}+$/u.test(matchSymbols),
-  "`\\p{sc=Mult}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mult}+$/u,
+  matchSymbols,
+  "\\p{sc=Mult}"
 );
 
 const nonMatchSymbols = buildString({
@@ -55,19 +59,23 @@ const nonMatchSymbols = buildString({
     [0x0112AA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Multani}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Multani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Multani}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Multani}"
 );
-assert(
-  /^\P{Script=Mult}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mult}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mult}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mult}"
 );
-assert(
-  /^\P{sc=Multani}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Multani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Multani}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Multani}"
 );
-assert(
-  /^\P{sc=Mult}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mult}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mult}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mult}"
 );

--- a/output/Script_-_Myanmar.js
+++ b/output/Script_-_Myanmar.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00AA60, 0x00AA7F]
   ]
 });
-assert(
-  /^\p{Script=Myanmar}+$/u.test(matchSymbols),
-  "`\\p{Script=Myanmar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Myanmar}+$/u,
+  matchSymbols,
+  "\\p{Script=Myanmar}"
 );
-assert(
-  /^\p{Script=Mymr}+$/u.test(matchSymbols),
-  "`\\p{Script=Mymr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Mymr}+$/u,
+  matchSymbols,
+  "\\p{Script=Mymr}"
 );
-assert(
-  /^\p{sc=Myanmar}+$/u.test(matchSymbols),
-  "`\\p{sc=Myanmar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Myanmar}+$/u,
+  matchSymbols,
+  "\\p{sc=Myanmar}"
 );
-assert(
-  /^\p{sc=Mymr}+$/u.test(matchSymbols),
-  "`\\p{sc=Mymr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Mymr}+$/u,
+  matchSymbols,
+  "\\p{sc=Mymr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Myanmar}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Myanmar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Myanmar}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Myanmar}"
 );
-assert(
-  /^\P{Script=Mymr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Mymr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Mymr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Mymr}"
 );
-assert(
-  /^\P{sc=Myanmar}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Myanmar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Myanmar}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Myanmar}"
 );
-assert(
-  /^\P{sc=Mymr}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Mymr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Mymr}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Mymr}"
 );

--- a/output/Script_-_Nabataean.js
+++ b/output/Script_-_Nabataean.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0108A7, 0x0108AF]
   ]
 });
-assert(
-  /^\p{Script=Nabataean}+$/u.test(matchSymbols),
-  "`\\p{Script=Nabataean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Nabataean}+$/u,
+  matchSymbols,
+  "\\p{Script=Nabataean}"
 );
-assert(
-  /^\p{Script=Nbat}+$/u.test(matchSymbols),
-  "`\\p{Script=Nbat}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Nbat}+$/u,
+  matchSymbols,
+  "\\p{Script=Nbat}"
 );
-assert(
-  /^\p{sc=Nabataean}+$/u.test(matchSymbols),
-  "`\\p{sc=Nabataean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Nabataean}+$/u,
+  matchSymbols,
+  "\\p{sc=Nabataean}"
 );
-assert(
-  /^\p{sc=Nbat}+$/u.test(matchSymbols),
-  "`\\p{sc=Nbat}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Nbat}+$/u,
+  matchSymbols,
+  "\\p{sc=Nbat}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0108B0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Nabataean}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Nabataean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Nabataean}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Nabataean}"
 );
-assert(
-  /^\P{Script=Nbat}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Nbat}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Nbat}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Nbat}"
 );
-assert(
-  /^\P{sc=Nabataean}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Nabataean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Nabataean}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Nabataean}"
 );
-assert(
-  /^\P{sc=Nbat}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Nbat}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Nbat}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Nbat}"
 );

--- a/output/Script_-_New_Tai_Lue.js
+++ b/output/Script_-_New_Tai_Lue.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x0019DE, 0x0019DF]
   ]
 });
-assert(
-  /^\p{Script=New_Tai_Lue}+$/u.test(matchSymbols),
-  "`\\p{Script=New_Tai_Lue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=New_Tai_Lue}+$/u,
+  matchSymbols,
+  "\\p{Script=New_Tai_Lue}"
 );
-assert(
-  /^\p{Script=Talu}+$/u.test(matchSymbols),
-  "`\\p{Script=Talu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Talu}+$/u,
+  matchSymbols,
+  "\\p{Script=Talu}"
 );
-assert(
-  /^\p{sc=New_Tai_Lue}+$/u.test(matchSymbols),
-  "`\\p{sc=New_Tai_Lue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=New_Tai_Lue}+$/u,
+  matchSymbols,
+  "\\p{sc=New_Tai_Lue}"
 );
-assert(
-  /^\p{sc=Talu}+$/u.test(matchSymbols),
-  "`\\p{sc=Talu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Talu}+$/u,
+  matchSymbols,
+  "\\p{sc=Talu}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=New_Tai_Lue}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=New_Tai_Lue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=New_Tai_Lue}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=New_Tai_Lue}"
 );
-assert(
-  /^\P{Script=Talu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Talu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Talu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Talu}"
 );
-assert(
-  /^\P{sc=New_Tai_Lue}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=New_Tai_Lue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=New_Tai_Lue}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=New_Tai_Lue}"
 );
-assert(
-  /^\P{sc=Talu}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Talu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Talu}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Talu}"
 );

--- a/output/Script_-_Newa.js
+++ b/output/Script_-_Newa.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x011400, 0x011459]
   ]
 });
-assert(
-  /^\p{Script=Newa}+$/u.test(matchSymbols),
-  "`\\p{Script=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Newa}+$/u,
+  matchSymbols,
+  "\\p{Script=Newa}"
 );
-assert(
-  /^\p{Script=Newa}+$/u.test(matchSymbols),
-  "`\\p{Script=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Newa}+$/u,
+  matchSymbols,
+  "\\p{Script=Newa}"
 );
-assert(
-  /^\p{sc=Newa}+$/u.test(matchSymbols),
-  "`\\p{sc=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Newa}+$/u,
+  matchSymbols,
+  "\\p{sc=Newa}"
 );
-assert(
-  /^\p{sc=Newa}+$/u.test(matchSymbols),
-  "`\\p{sc=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Newa}+$/u,
+  matchSymbols,
+  "\\p{sc=Newa}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x01145E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Newa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Newa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Newa}"
 );
-assert(
-  /^\P{Script=Newa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Newa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Newa}"
 );
-assert(
-  /^\P{sc=Newa}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Newa}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Newa}"
 );
-assert(
-  /^\P{sc=Newa}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Newa}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Newa}"
 );

--- a/output/Script_-_Nko.js
+++ b/output/Script_-_Nko.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x0007C0, 0x0007FA]
   ]
 });
-assert(
-  /^\p{Script=Nko}+$/u.test(matchSymbols),
-  "`\\p{Script=Nko}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Nko}+$/u,
+  matchSymbols,
+  "\\p{Script=Nko}"
 );
-assert(
-  /^\p{Script=Nkoo}+$/u.test(matchSymbols),
-  "`\\p{Script=Nkoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Nkoo}+$/u,
+  matchSymbols,
+  "\\p{Script=Nkoo}"
 );
-assert(
-  /^\p{sc=Nko}+$/u.test(matchSymbols),
-  "`\\p{sc=Nko}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Nko}+$/u,
+  matchSymbols,
+  "\\p{sc=Nko}"
 );
-assert(
-  /^\p{sc=Nkoo}+$/u.test(matchSymbols),
-  "`\\p{sc=Nkoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Nkoo}+$/u,
+  matchSymbols,
+  "\\p{sc=Nkoo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Nko}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Nko}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Nko}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Nko}"
 );
-assert(
-  /^\P{Script=Nkoo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Nkoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Nkoo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Nkoo}"
 );
-assert(
-  /^\P{sc=Nko}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Nko}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Nko}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Nko}"
 );
-assert(
-  /^\P{sc=Nkoo}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Nkoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Nkoo}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Nkoo}"
 );

--- a/output/Script_-_Ogham.js
+++ b/output/Script_-_Ogham.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x001680, 0x00169C]
   ]
 });
-assert(
-  /^\p{Script=Ogham}+$/u.test(matchSymbols),
-  "`\\p{Script=Ogham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ogham}+$/u,
+  matchSymbols,
+  "\\p{Script=Ogham}"
 );
-assert(
-  /^\p{Script=Ogam}+$/u.test(matchSymbols),
-  "`\\p{Script=Ogam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ogam}+$/u,
+  matchSymbols,
+  "\\p{Script=Ogam}"
 );
-assert(
-  /^\p{sc=Ogham}+$/u.test(matchSymbols),
-  "`\\p{sc=Ogham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ogham}+$/u,
+  matchSymbols,
+  "\\p{sc=Ogham}"
 );
-assert(
-  /^\p{sc=Ogam}+$/u.test(matchSymbols),
-  "`\\p{sc=Ogam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ogam}+$/u,
+  matchSymbols,
+  "\\p{sc=Ogam}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Ogham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ogham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ogham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ogham}"
 );
-assert(
-  /^\P{Script=Ogam}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ogam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ogam}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ogam}"
 );
-assert(
-  /^\P{sc=Ogham}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ogham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ogham}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ogham}"
 );
-assert(
-  /^\P{sc=Ogam}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ogam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ogam}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ogam}"
 );

--- a/output/Script_-_Ol_Chiki.js
+++ b/output/Script_-_Ol_Chiki.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x001C50, 0x001C7F]
   ]
 });
-assert(
-  /^\p{Script=Ol_Chiki}+$/u.test(matchSymbols),
-  "`\\p{Script=Ol_Chiki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ol_Chiki}+$/u,
+  matchSymbols,
+  "\\p{Script=Ol_Chiki}"
 );
-assert(
-  /^\p{Script=Olck}+$/u.test(matchSymbols),
-  "`\\p{Script=Olck}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Olck}+$/u,
+  matchSymbols,
+  "\\p{Script=Olck}"
 );
-assert(
-  /^\p{sc=Ol_Chiki}+$/u.test(matchSymbols),
-  "`\\p{sc=Ol_Chiki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ol_Chiki}+$/u,
+  matchSymbols,
+  "\\p{sc=Ol_Chiki}"
 );
-assert(
-  /^\p{sc=Olck}+$/u.test(matchSymbols),
-  "`\\p{sc=Olck}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Olck}+$/u,
+  matchSymbols,
+  "\\p{sc=Olck}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Ol_Chiki}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ol_Chiki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ol_Chiki}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ol_Chiki}"
 );
-assert(
-  /^\P{Script=Olck}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Olck}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Olck}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Olck}"
 );
-assert(
-  /^\P{sc=Ol_Chiki}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ol_Chiki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ol_Chiki}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ol_Chiki}"
 );
-assert(
-  /^\P{sc=Olck}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Olck}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Olck}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Olck}"
 );

--- a/output/Script_-_Old_Hungarian.js
+++ b/output/Script_-_Old_Hungarian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010CFA, 0x010CFF]
   ]
 });
-assert(
-  /^\p{Script=Old_Hungarian}+$/u.test(matchSymbols),
-  "`\\p{Script=Old_Hungarian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Old_Hungarian}+$/u,
+  matchSymbols,
+  "\\p{Script=Old_Hungarian}"
 );
-assert(
-  /^\p{Script=Hung}+$/u.test(matchSymbols),
-  "`\\p{Script=Hung}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hung}+$/u,
+  matchSymbols,
+  "\\p{Script=Hung}"
 );
-assert(
-  /^\p{sc=Old_Hungarian}+$/u.test(matchSymbols),
-  "`\\p{sc=Old_Hungarian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Old_Hungarian}+$/u,
+  matchSymbols,
+  "\\p{sc=Old_Hungarian}"
 );
-assert(
-  /^\p{sc=Hung}+$/u.test(matchSymbols),
-  "`\\p{sc=Hung}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hung}+$/u,
+  matchSymbols,
+  "\\p{sc=Hung}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x010D00, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Old_Hungarian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Old_Hungarian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Old_Hungarian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Old_Hungarian}"
 );
-assert(
-  /^\P{Script=Hung}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hung}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hung}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hung}"
 );
-assert(
-  /^\P{sc=Old_Hungarian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Old_Hungarian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Old_Hungarian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Old_Hungarian}"
 );
-assert(
-  /^\P{sc=Hung}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hung}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hung}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hung}"
 );

--- a/output/Script_-_Old_Italic.js
+++ b/output/Script_-_Old_Italic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010300, 0x010323]
   ]
 });
-assert(
-  /^\p{Script=Old_Italic}+$/u.test(matchSymbols),
-  "`\\p{Script=Old_Italic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Old_Italic}+$/u,
+  matchSymbols,
+  "\\p{Script=Old_Italic}"
 );
-assert(
-  /^\p{Script=Ital}+$/u.test(matchSymbols),
-  "`\\p{Script=Ital}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ital}+$/u,
+  matchSymbols,
+  "\\p{Script=Ital}"
 );
-assert(
-  /^\p{sc=Old_Italic}+$/u.test(matchSymbols),
-  "`\\p{sc=Old_Italic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Old_Italic}+$/u,
+  matchSymbols,
+  "\\p{sc=Old_Italic}"
 );
-assert(
-  /^\p{sc=Ital}+$/u.test(matchSymbols),
-  "`\\p{sc=Ital}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ital}+$/u,
+  matchSymbols,
+  "\\p{sc=Ital}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010324, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Old_Italic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Old_Italic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Old_Italic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Old_Italic}"
 );
-assert(
-  /^\P{Script=Ital}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ital}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ital}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ital}"
 );
-assert(
-  /^\P{sc=Old_Italic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Old_Italic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Old_Italic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Old_Italic}"
 );
-assert(
-  /^\P{sc=Ital}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ital}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ital}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ital}"
 );

--- a/output/Script_-_Old_North_Arabian.js
+++ b/output/Script_-_Old_North_Arabian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010A80, 0x010A9F]
   ]
 });
-assert(
-  /^\p{Script=Old_North_Arabian}+$/u.test(matchSymbols),
-  "`\\p{Script=Old_North_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Old_North_Arabian}+$/u,
+  matchSymbols,
+  "\\p{Script=Old_North_Arabian}"
 );
-assert(
-  /^\p{Script=Narb}+$/u.test(matchSymbols),
-  "`\\p{Script=Narb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Narb}+$/u,
+  matchSymbols,
+  "\\p{Script=Narb}"
 );
-assert(
-  /^\p{sc=Old_North_Arabian}+$/u.test(matchSymbols),
-  "`\\p{sc=Old_North_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Old_North_Arabian}+$/u,
+  matchSymbols,
+  "\\p{sc=Old_North_Arabian}"
 );
-assert(
-  /^\p{sc=Narb}+$/u.test(matchSymbols),
-  "`\\p{sc=Narb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Narb}+$/u,
+  matchSymbols,
+  "\\p{sc=Narb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010AA0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Old_North_Arabian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Old_North_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Old_North_Arabian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Old_North_Arabian}"
 );
-assert(
-  /^\P{Script=Narb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Narb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Narb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Narb}"
 );
-assert(
-  /^\P{sc=Old_North_Arabian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Old_North_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Old_North_Arabian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Old_North_Arabian}"
 );
-assert(
-  /^\P{sc=Narb}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Narb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Narb}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Narb}"
 );

--- a/output/Script_-_Old_Permic.js
+++ b/output/Script_-_Old_Permic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010350, 0x01037A]
   ]
 });
-assert(
-  /^\p{Script=Old_Permic}+$/u.test(matchSymbols),
-  "`\\p{Script=Old_Permic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Old_Permic}+$/u,
+  matchSymbols,
+  "\\p{Script=Old_Permic}"
 );
-assert(
-  /^\p{Script=Perm}+$/u.test(matchSymbols),
-  "`\\p{Script=Perm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Perm}+$/u,
+  matchSymbols,
+  "\\p{Script=Perm}"
 );
-assert(
-  /^\p{sc=Old_Permic}+$/u.test(matchSymbols),
-  "`\\p{sc=Old_Permic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Old_Permic}+$/u,
+  matchSymbols,
+  "\\p{sc=Old_Permic}"
 );
-assert(
-  /^\p{sc=Perm}+$/u.test(matchSymbols),
-  "`\\p{sc=Perm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Perm}+$/u,
+  matchSymbols,
+  "\\p{sc=Perm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x01037B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Old_Permic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Old_Permic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Old_Permic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Old_Permic}"
 );
-assert(
-  /^\P{Script=Perm}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Perm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Perm}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Perm}"
 );
-assert(
-  /^\P{sc=Old_Permic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Old_Permic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Old_Permic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Old_Permic}"
 );
-assert(
-  /^\P{sc=Perm}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Perm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Perm}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Perm}"
 );

--- a/output/Script_-_Old_Persian.js
+++ b/output/Script_-_Old_Persian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0103C8, 0x0103D5]
   ]
 });
-assert(
-  /^\p{Script=Old_Persian}+$/u.test(matchSymbols),
-  "`\\p{Script=Old_Persian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Old_Persian}+$/u,
+  matchSymbols,
+  "\\p{Script=Old_Persian}"
 );
-assert(
-  /^\p{Script=Xpeo}+$/u.test(matchSymbols),
-  "`\\p{Script=Xpeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Xpeo}+$/u,
+  matchSymbols,
+  "\\p{Script=Xpeo}"
 );
-assert(
-  /^\p{sc=Old_Persian}+$/u.test(matchSymbols),
-  "`\\p{sc=Old_Persian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Old_Persian}+$/u,
+  matchSymbols,
+  "\\p{sc=Old_Persian}"
 );
-assert(
-  /^\p{sc=Xpeo}+$/u.test(matchSymbols),
-  "`\\p{sc=Xpeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Xpeo}+$/u,
+  matchSymbols,
+  "\\p{sc=Xpeo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0103D6, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Old_Persian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Old_Persian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Old_Persian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Old_Persian}"
 );
-assert(
-  /^\P{Script=Xpeo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Xpeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Xpeo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Xpeo}"
 );
-assert(
-  /^\P{sc=Old_Persian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Old_Persian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Old_Persian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Old_Persian}"
 );
-assert(
-  /^\P{sc=Xpeo}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Xpeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Xpeo}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Xpeo}"
 );

--- a/output/Script_-_Old_South_Arabian.js
+++ b/output/Script_-_Old_South_Arabian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010A60, 0x010A7F]
   ]
 });
-assert(
-  /^\p{Script=Old_South_Arabian}+$/u.test(matchSymbols),
-  "`\\p{Script=Old_South_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Old_South_Arabian}+$/u,
+  matchSymbols,
+  "\\p{Script=Old_South_Arabian}"
 );
-assert(
-  /^\p{Script=Sarb}+$/u.test(matchSymbols),
-  "`\\p{Script=Sarb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sarb}+$/u,
+  matchSymbols,
+  "\\p{Script=Sarb}"
 );
-assert(
-  /^\p{sc=Old_South_Arabian}+$/u.test(matchSymbols),
-  "`\\p{sc=Old_South_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Old_South_Arabian}+$/u,
+  matchSymbols,
+  "\\p{sc=Old_South_Arabian}"
 );
-assert(
-  /^\p{sc=Sarb}+$/u.test(matchSymbols),
-  "`\\p{sc=Sarb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sarb}+$/u,
+  matchSymbols,
+  "\\p{sc=Sarb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010A80, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Old_South_Arabian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Old_South_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Old_South_Arabian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Old_South_Arabian}"
 );
-assert(
-  /^\P{Script=Sarb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sarb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sarb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sarb}"
 );
-assert(
-  /^\P{sc=Old_South_Arabian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Old_South_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Old_South_Arabian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Old_South_Arabian}"
 );
-assert(
-  /^\P{sc=Sarb}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sarb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sarb}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sarb}"
 );

--- a/output/Script_-_Old_Turkic.js
+++ b/output/Script_-_Old_Turkic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010C00, 0x010C48]
   ]
 });
-assert(
-  /^\p{Script=Old_Turkic}+$/u.test(matchSymbols),
-  "`\\p{Script=Old_Turkic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Old_Turkic}+$/u,
+  matchSymbols,
+  "\\p{Script=Old_Turkic}"
 );
-assert(
-  /^\p{Script=Orkh}+$/u.test(matchSymbols),
-  "`\\p{Script=Orkh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Orkh}+$/u,
+  matchSymbols,
+  "\\p{Script=Orkh}"
 );
-assert(
-  /^\p{sc=Old_Turkic}+$/u.test(matchSymbols),
-  "`\\p{sc=Old_Turkic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Old_Turkic}+$/u,
+  matchSymbols,
+  "\\p{sc=Old_Turkic}"
 );
-assert(
-  /^\p{sc=Orkh}+$/u.test(matchSymbols),
-  "`\\p{sc=Orkh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Orkh}+$/u,
+  matchSymbols,
+  "\\p{sc=Orkh}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010C49, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Old_Turkic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Old_Turkic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Old_Turkic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Old_Turkic}"
 );
-assert(
-  /^\P{Script=Orkh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Orkh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Orkh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Orkh}"
 );
-assert(
-  /^\P{sc=Old_Turkic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Old_Turkic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Old_Turkic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Old_Turkic}"
 );
-assert(
-  /^\P{sc=Orkh}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Orkh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Orkh}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Orkh}"
 );

--- a/output/Script_-_Oriya.js
+++ b/output/Script_-_Oriya.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -32,21 +32,25 @@ const matchSymbols = buildString({
     [0x000B66, 0x000B77]
   ]
 });
-assert(
-  /^\p{Script=Oriya}+$/u.test(matchSymbols),
-  "`\\p{Script=Oriya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Oriya}+$/u,
+  matchSymbols,
+  "\\p{Script=Oriya}"
 );
-assert(
-  /^\p{Script=Orya}+$/u.test(matchSymbols),
-  "`\\p{Script=Orya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Orya}+$/u,
+  matchSymbols,
+  "\\p{Script=Orya}"
 );
-assert(
-  /^\p{sc=Oriya}+$/u.test(matchSymbols),
-  "`\\p{sc=Oriya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Oriya}+$/u,
+  matchSymbols,
+  "\\p{sc=Oriya}"
 );
-assert(
-  /^\p{sc=Orya}+$/u.test(matchSymbols),
-  "`\\p{sc=Orya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Orya}+$/u,
+  matchSymbols,
+  "\\p{sc=Orya}"
 );
 
 const nonMatchSymbols = buildString({
@@ -72,19 +76,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Oriya}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Oriya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Oriya}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Oriya}"
 );
-assert(
-  /^\P{Script=Orya}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Orya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Orya}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Orya}"
 );
-assert(
-  /^\P{sc=Oriya}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Oriya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Oriya}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Oriya}"
 );
-assert(
-  /^\P{sc=Orya}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Orya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Orya}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Orya}"
 );

--- a/output/Script_-_Osage.js
+++ b/output/Script_-_Osage.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0104D8, 0x0104FB]
   ]
 });
-assert(
-  /^\p{Script=Osage}+$/u.test(matchSymbols),
-  "`\\p{Script=Osage}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Osage}+$/u,
+  matchSymbols,
+  "\\p{Script=Osage}"
 );
-assert(
-  /^\p{Script=Osge}+$/u.test(matchSymbols),
-  "`\\p{Script=Osge}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Osge}+$/u,
+  matchSymbols,
+  "\\p{Script=Osge}"
 );
-assert(
-  /^\p{sc=Osage}+$/u.test(matchSymbols),
-  "`\\p{sc=Osage}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Osage}+$/u,
+  matchSymbols,
+  "\\p{sc=Osage}"
 );
-assert(
-  /^\p{sc=Osge}+$/u.test(matchSymbols),
-  "`\\p{sc=Osge}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Osge}+$/u,
+  matchSymbols,
+  "\\p{sc=Osge}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0104FC, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Osage}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Osage}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Osage}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Osage}"
 );
-assert(
-  /^\P{Script=Osge}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Osge}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Osge}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Osge}"
 );
-assert(
-  /^\P{sc=Osage}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Osage}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Osage}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Osage}"
 );
-assert(
-  /^\P{sc=Osge}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Osge}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Osge}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Osge}"
 );

--- a/output/Script_-_Osmanya.js
+++ b/output/Script_-_Osmanya.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0104A0, 0x0104A9]
   ]
 });
-assert(
-  /^\p{Script=Osmanya}+$/u.test(matchSymbols),
-  "`\\p{Script=Osmanya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Osmanya}+$/u,
+  matchSymbols,
+  "\\p{Script=Osmanya}"
 );
-assert(
-  /^\p{Script=Osma}+$/u.test(matchSymbols),
-  "`\\p{Script=Osma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Osma}+$/u,
+  matchSymbols,
+  "\\p{Script=Osma}"
 );
-assert(
-  /^\p{sc=Osmanya}+$/u.test(matchSymbols),
-  "`\\p{sc=Osmanya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Osmanya}+$/u,
+  matchSymbols,
+  "\\p{sc=Osmanya}"
 );
-assert(
-  /^\p{sc=Osma}+$/u.test(matchSymbols),
-  "`\\p{sc=Osma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Osma}+$/u,
+  matchSymbols,
+  "\\p{sc=Osma}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0104AA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Osmanya}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Osmanya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Osmanya}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Osmanya}"
 );
-assert(
-  /^\P{Script=Osma}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Osma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Osma}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Osma}"
 );
-assert(
-  /^\P{sc=Osmanya}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Osmanya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Osmanya}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Osmanya}"
 );
-assert(
-  /^\P{sc=Osma}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Osma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Osma}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Osma}"
 );

--- a/output/Script_-_Pahawh_Hmong.js
+++ b/output/Script_-_Pahawh_Hmong.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x016B7D, 0x016B8F]
   ]
 });
-assert(
-  /^\p{Script=Pahawh_Hmong}+$/u.test(matchSymbols),
-  "`\\p{Script=Pahawh_Hmong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Pahawh_Hmong}+$/u,
+  matchSymbols,
+  "\\p{Script=Pahawh_Hmong}"
 );
-assert(
-  /^\p{Script=Hmng}+$/u.test(matchSymbols),
-  "`\\p{Script=Hmng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Hmng}+$/u,
+  matchSymbols,
+  "\\p{Script=Hmng}"
 );
-assert(
-  /^\p{sc=Pahawh_Hmong}+$/u.test(matchSymbols),
-  "`\\p{sc=Pahawh_Hmong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Pahawh_Hmong}+$/u,
+  matchSymbols,
+  "\\p{sc=Pahawh_Hmong}"
 );
-assert(
-  /^\p{sc=Hmng}+$/u.test(matchSymbols),
-  "`\\p{sc=Hmng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Hmng}+$/u,
+  matchSymbols,
+  "\\p{sc=Hmng}"
 );
 
 const nonMatchSymbols = buildString({
@@ -54,19 +58,23 @@ const nonMatchSymbols = buildString({
     [0x016B90, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Pahawh_Hmong}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Pahawh_Hmong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Pahawh_Hmong}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Pahawh_Hmong}"
 );
-assert(
-  /^\P{Script=Hmng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Hmng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Hmng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Hmng}"
 );
-assert(
-  /^\P{sc=Pahawh_Hmong}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Pahawh_Hmong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Pahawh_Hmong}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Pahawh_Hmong}"
 );
-assert(
-  /^\P{sc=Hmng}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Hmng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Hmng}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Hmng}"
 );

--- a/output/Script_-_Palmyrene.js
+++ b/output/Script_-_Palmyrene.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010860, 0x01087F]
   ]
 });
-assert(
-  /^\p{Script=Palmyrene}+$/u.test(matchSymbols),
-  "`\\p{Script=Palmyrene}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Palmyrene}+$/u,
+  matchSymbols,
+  "\\p{Script=Palmyrene}"
 );
-assert(
-  /^\p{Script=Palm}+$/u.test(matchSymbols),
-  "`\\p{Script=Palm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Palm}+$/u,
+  matchSymbols,
+  "\\p{Script=Palm}"
 );
-assert(
-  /^\p{sc=Palmyrene}+$/u.test(matchSymbols),
-  "`\\p{sc=Palmyrene}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Palmyrene}+$/u,
+  matchSymbols,
+  "\\p{sc=Palmyrene}"
 );
-assert(
-  /^\p{sc=Palm}+$/u.test(matchSymbols),
-  "`\\p{sc=Palm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Palm}+$/u,
+  matchSymbols,
+  "\\p{sc=Palm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010880, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Palmyrene}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Palmyrene}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Palmyrene}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Palmyrene}"
 );
-assert(
-  /^\P{Script=Palm}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Palm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Palm}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Palm}"
 );
-assert(
-  /^\P{sc=Palmyrene}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Palmyrene}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Palmyrene}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Palmyrene}"
 );
-assert(
-  /^\P{sc=Palm}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Palm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Palm}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Palm}"
 );

--- a/output/Script_-_Pau_Cin_Hau.js
+++ b/output/Script_-_Pau_Cin_Hau.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x011AC0, 0x011AF8]
   ]
 });
-assert(
-  /^\p{Script=Pau_Cin_Hau}+$/u.test(matchSymbols),
-  "`\\p{Script=Pau_Cin_Hau}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Pau_Cin_Hau}+$/u,
+  matchSymbols,
+  "\\p{Script=Pau_Cin_Hau}"
 );
-assert(
-  /^\p{Script=Pauc}+$/u.test(matchSymbols),
-  "`\\p{Script=Pauc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Pauc}+$/u,
+  matchSymbols,
+  "\\p{Script=Pauc}"
 );
-assert(
-  /^\p{sc=Pau_Cin_Hau}+$/u.test(matchSymbols),
-  "`\\p{sc=Pau_Cin_Hau}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Pau_Cin_Hau}+$/u,
+  matchSymbols,
+  "\\p{sc=Pau_Cin_Hau}"
 );
-assert(
-  /^\p{sc=Pauc}+$/u.test(matchSymbols),
-  "`\\p{sc=Pauc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Pauc}+$/u,
+  matchSymbols,
+  "\\p{sc=Pauc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x011AF9, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Pau_Cin_Hau}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Pau_Cin_Hau}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Pau_Cin_Hau}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Pau_Cin_Hau}"
 );
-assert(
-  /^\P{Script=Pauc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Pauc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Pauc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Pauc}"
 );
-assert(
-  /^\P{sc=Pau_Cin_Hau}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Pau_Cin_Hau}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Pau_Cin_Hau}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Pau_Cin_Hau}"
 );
-assert(
-  /^\P{sc=Pauc}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Pauc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Pauc}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Pauc}"
 );

--- a/output/Script_-_Phags_Pa.js
+++ b/output/Script_-_Phags_Pa.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x00A840, 0x00A877]
   ]
 });
-assert(
-  /^\p{Script=Phags_Pa}+$/u.test(matchSymbols),
-  "`\\p{Script=Phags_Pa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Phags_Pa}+$/u,
+  matchSymbols,
+  "\\p{Script=Phags_Pa}"
 );
-assert(
-  /^\p{Script=Phag}+$/u.test(matchSymbols),
-  "`\\p{Script=Phag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Phag}+$/u,
+  matchSymbols,
+  "\\p{Script=Phag}"
 );
-assert(
-  /^\p{sc=Phags_Pa}+$/u.test(matchSymbols),
-  "`\\p{sc=Phags_Pa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Phags_Pa}+$/u,
+  matchSymbols,
+  "\\p{sc=Phags_Pa}"
 );
-assert(
-  /^\p{sc=Phag}+$/u.test(matchSymbols),
-  "`\\p{sc=Phag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Phag}+$/u,
+  matchSymbols,
+  "\\p{sc=Phag}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Phags_Pa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Phags_Pa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Phags_Pa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Phags_Pa}"
 );
-assert(
-  /^\P{Script=Phag}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Phag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Phag}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Phag}"
 );
-assert(
-  /^\P{sc=Phags_Pa}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Phags_Pa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Phags_Pa}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Phags_Pa}"
 );
-assert(
-  /^\P{sc=Phag}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Phag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Phag}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Phag}"
 );

--- a/output/Script_-_Phoenician.js
+++ b/output/Script_-_Phoenician.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010900, 0x01091B]
   ]
 });
-assert(
-  /^\p{Script=Phoenician}+$/u.test(matchSymbols),
-  "`\\p{Script=Phoenician}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Phoenician}+$/u,
+  matchSymbols,
+  "\\p{Script=Phoenician}"
 );
-assert(
-  /^\p{Script=Phnx}+$/u.test(matchSymbols),
-  "`\\p{Script=Phnx}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Phnx}+$/u,
+  matchSymbols,
+  "\\p{Script=Phnx}"
 );
-assert(
-  /^\p{sc=Phoenician}+$/u.test(matchSymbols),
-  "`\\p{sc=Phoenician}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Phoenician}+$/u,
+  matchSymbols,
+  "\\p{sc=Phoenician}"
 );
-assert(
-  /^\p{sc=Phnx}+$/u.test(matchSymbols),
-  "`\\p{sc=Phnx}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Phnx}+$/u,
+  matchSymbols,
+  "\\p{sc=Phnx}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x010920, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Phoenician}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Phoenician}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Phoenician}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Phoenician}"
 );
-assert(
-  /^\P{Script=Phnx}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Phnx}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Phnx}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Phnx}"
 );
-assert(
-  /^\P{sc=Phoenician}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Phoenician}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Phoenician}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Phoenician}"
 );
-assert(
-  /^\P{sc=Phnx}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Phnx}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Phnx}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Phnx}"
 );

--- a/output/Script_-_Psalter_Pahlavi.js
+++ b/output/Script_-_Psalter_Pahlavi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010BA9, 0x010BAF]
   ]
 });
-assert(
-  /^\p{Script=Psalter_Pahlavi}+$/u.test(matchSymbols),
-  "`\\p{Script=Psalter_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Psalter_Pahlavi}+$/u,
+  matchSymbols,
+  "\\p{Script=Psalter_Pahlavi}"
 );
-assert(
-  /^\p{Script=Phlp}+$/u.test(matchSymbols),
-  "`\\p{Script=Phlp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Phlp}+$/u,
+  matchSymbols,
+  "\\p{Script=Phlp}"
 );
-assert(
-  /^\p{sc=Psalter_Pahlavi}+$/u.test(matchSymbols),
-  "`\\p{sc=Psalter_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Psalter_Pahlavi}+$/u,
+  matchSymbols,
+  "\\p{sc=Psalter_Pahlavi}"
 );
-assert(
-  /^\p{sc=Phlp}+$/u.test(matchSymbols),
-  "`\\p{sc=Phlp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Phlp}+$/u,
+  matchSymbols,
+  "\\p{sc=Phlp}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x010BB0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Psalter_Pahlavi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Psalter_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Psalter_Pahlavi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Psalter_Pahlavi}"
 );
-assert(
-  /^\P{Script=Phlp}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Phlp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Phlp}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Phlp}"
 );
-assert(
-  /^\P{sc=Psalter_Pahlavi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Psalter_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Psalter_Pahlavi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Psalter_Pahlavi}"
 );
-assert(
-  /^\P{sc=Phlp}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Phlp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Phlp}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Phlp}"
 );

--- a/output/Script_-_Rejang.js
+++ b/output/Script_-_Rejang.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00A930, 0x00A953]
   ]
 });
-assert(
-  /^\p{Script=Rejang}+$/u.test(matchSymbols),
-  "`\\p{Script=Rejang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Rejang}+$/u,
+  matchSymbols,
+  "\\p{Script=Rejang}"
 );
-assert(
-  /^\p{Script=Rjng}+$/u.test(matchSymbols),
-  "`\\p{Script=Rjng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Rjng}+$/u,
+  matchSymbols,
+  "\\p{Script=Rjng}"
 );
-assert(
-  /^\p{sc=Rejang}+$/u.test(matchSymbols),
-  "`\\p{sc=Rejang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Rejang}+$/u,
+  matchSymbols,
+  "\\p{sc=Rejang}"
 );
-assert(
-  /^\p{sc=Rjng}+$/u.test(matchSymbols),
-  "`\\p{sc=Rjng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Rjng}+$/u,
+  matchSymbols,
+  "\\p{sc=Rjng}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Rejang}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Rejang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Rejang}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Rejang}"
 );
-assert(
-  /^\P{Script=Rjng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Rjng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Rjng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Rjng}"
 );
-assert(
-  /^\P{sc=Rejang}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Rejang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Rejang}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Rejang}"
 );
-assert(
-  /^\P{sc=Rjng}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Rjng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Rjng}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Rjng}"
 );

--- a/output/Script_-_Runic.js
+++ b/output/Script_-_Runic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0016EE, 0x0016F8]
   ]
 });
-assert(
-  /^\p{Script=Runic}+$/u.test(matchSymbols),
-  "`\\p{Script=Runic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Runic}+$/u,
+  matchSymbols,
+  "\\p{Script=Runic}"
 );
-assert(
-  /^\p{Script=Runr}+$/u.test(matchSymbols),
-  "`\\p{Script=Runr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Runr}+$/u,
+  matchSymbols,
+  "\\p{Script=Runr}"
 );
-assert(
-  /^\p{sc=Runic}+$/u.test(matchSymbols),
-  "`\\p{sc=Runic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Runic}+$/u,
+  matchSymbols,
+  "\\p{sc=Runic}"
 );
-assert(
-  /^\p{sc=Runr}+$/u.test(matchSymbols),
-  "`\\p{sc=Runr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Runr}+$/u,
+  matchSymbols,
+  "\\p{sc=Runr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Runic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Runic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Runic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Runic}"
 );
-assert(
-  /^\P{Script=Runr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Runr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Runr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Runr}"
 );
-assert(
-  /^\P{sc=Runic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Runic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Runic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Runic}"
 );
-assert(
-  /^\P{sc=Runr}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Runr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Runr}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Runr}"
 );

--- a/output/Script_-_Samaritan.js
+++ b/output/Script_-_Samaritan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x000830, 0x00083E]
   ]
 });
-assert(
-  /^\p{Script=Samaritan}+$/u.test(matchSymbols),
-  "`\\p{Script=Samaritan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Samaritan}+$/u,
+  matchSymbols,
+  "\\p{Script=Samaritan}"
 );
-assert(
-  /^\p{Script=Samr}+$/u.test(matchSymbols),
-  "`\\p{Script=Samr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Samr}+$/u,
+  matchSymbols,
+  "\\p{Script=Samr}"
 );
-assert(
-  /^\p{sc=Samaritan}+$/u.test(matchSymbols),
-  "`\\p{sc=Samaritan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Samaritan}+$/u,
+  matchSymbols,
+  "\\p{sc=Samaritan}"
 );
-assert(
-  /^\p{sc=Samr}+$/u.test(matchSymbols),
-  "`\\p{sc=Samr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Samr}+$/u,
+  matchSymbols,
+  "\\p{sc=Samr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Samaritan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Samaritan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Samaritan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Samaritan}"
 );
-assert(
-  /^\P{Script=Samr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Samr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Samr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Samr}"
 );
-assert(
-  /^\P{sc=Samaritan}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Samaritan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Samaritan}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Samaritan}"
 );
-assert(
-  /^\P{sc=Samr}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Samr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Samr}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Samr}"
 );

--- a/output/Script_-_Saurashtra.js
+++ b/output/Script_-_Saurashtra.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x00A8CE, 0x00A8D9]
   ]
 });
-assert(
-  /^\p{Script=Saurashtra}+$/u.test(matchSymbols),
-  "`\\p{Script=Saurashtra}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Saurashtra}+$/u,
+  matchSymbols,
+  "\\p{Script=Saurashtra}"
 );
-assert(
-  /^\p{Script=Saur}+$/u.test(matchSymbols),
-  "`\\p{Script=Saur}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Saur}+$/u,
+  matchSymbols,
+  "\\p{Script=Saur}"
 );
-assert(
-  /^\p{sc=Saurashtra}+$/u.test(matchSymbols),
-  "`\\p{sc=Saurashtra}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Saurashtra}+$/u,
+  matchSymbols,
+  "\\p{sc=Saurashtra}"
 );
-assert(
-  /^\p{sc=Saur}+$/u.test(matchSymbols),
-  "`\\p{sc=Saur}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Saur}+$/u,
+  matchSymbols,
+  "\\p{sc=Saur}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Saurashtra}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Saurashtra}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Saurashtra}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Saurashtra}"
 );
-assert(
-  /^\P{Script=Saur}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Saur}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Saur}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Saur}"
 );
-assert(
-  /^\P{sc=Saurashtra}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Saurashtra}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Saurashtra}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Saurashtra}"
 );
-assert(
-  /^\P{sc=Saur}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Saur}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Saur}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Saur}"
 );

--- a/output/Script_-_Sharada.js
+++ b/output/Script_-_Sharada.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0111D0, 0x0111DF]
   ]
 });
-assert(
-  /^\p{Script=Sharada}+$/u.test(matchSymbols),
-  "`\\p{Script=Sharada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sharada}+$/u,
+  matchSymbols,
+  "\\p{Script=Sharada}"
 );
-assert(
-  /^\p{Script=Shrd}+$/u.test(matchSymbols),
-  "`\\p{Script=Shrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Shrd}+$/u,
+  matchSymbols,
+  "\\p{Script=Shrd}"
 );
-assert(
-  /^\p{sc=Sharada}+$/u.test(matchSymbols),
-  "`\\p{sc=Sharada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sharada}+$/u,
+  matchSymbols,
+  "\\p{sc=Sharada}"
 );
-assert(
-  /^\p{sc=Shrd}+$/u.test(matchSymbols),
-  "`\\p{sc=Shrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Shrd}+$/u,
+  matchSymbols,
+  "\\p{sc=Shrd}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0111E0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Sharada}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sharada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sharada}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sharada}"
 );
-assert(
-  /^\P{Script=Shrd}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Shrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Shrd}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Shrd}"
 );
-assert(
-  /^\P{sc=Sharada}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sharada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sharada}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sharada}"
 );
-assert(
-  /^\P{sc=Shrd}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Shrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Shrd}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Shrd}"
 );

--- a/output/Script_-_Shavian.js
+++ b/output/Script_-_Shavian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010450, 0x01047F]
   ]
 });
-assert(
-  /^\p{Script=Shavian}+$/u.test(matchSymbols),
-  "`\\p{Script=Shavian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Shavian}+$/u,
+  matchSymbols,
+  "\\p{Script=Shavian}"
 );
-assert(
-  /^\p{Script=Shaw}+$/u.test(matchSymbols),
-  "`\\p{Script=Shaw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Shaw}+$/u,
+  matchSymbols,
+  "\\p{Script=Shaw}"
 );
-assert(
-  /^\p{sc=Shavian}+$/u.test(matchSymbols),
-  "`\\p{sc=Shavian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Shavian}+$/u,
+  matchSymbols,
+  "\\p{sc=Shavian}"
 );
-assert(
-  /^\p{sc=Shaw}+$/u.test(matchSymbols),
-  "`\\p{sc=Shaw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Shaw}+$/u,
+  matchSymbols,
+  "\\p{sc=Shaw}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010480, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Shavian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Shavian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Shavian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Shavian}"
 );
-assert(
-  /^\P{Script=Shaw}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Shaw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Shaw}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Shaw}"
 );
-assert(
-  /^\P{sc=Shavian}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Shavian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Shavian}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Shavian}"
 );
-assert(
-  /^\P{sc=Shaw}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Shaw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Shaw}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Shaw}"
 );

--- a/output/Script_-_Siddham.js
+++ b/output/Script_-_Siddham.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0115B8, 0x0115DD]
   ]
 });
-assert(
-  /^\p{Script=Siddham}+$/u.test(matchSymbols),
-  "`\\p{Script=Siddham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Siddham}+$/u,
+  matchSymbols,
+  "\\p{Script=Siddham}"
 );
-assert(
-  /^\p{Script=Sidd}+$/u.test(matchSymbols),
-  "`\\p{Script=Sidd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sidd}+$/u,
+  matchSymbols,
+  "\\p{Script=Sidd}"
 );
-assert(
-  /^\p{sc=Siddham}+$/u.test(matchSymbols),
-  "`\\p{sc=Siddham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Siddham}+$/u,
+  matchSymbols,
+  "\\p{sc=Siddham}"
 );
-assert(
-  /^\p{sc=Sidd}+$/u.test(matchSymbols),
-  "`\\p{sc=Sidd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sidd}+$/u,
+  matchSymbols,
+  "\\p{sc=Sidd}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0115DE, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Siddham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Siddham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Siddham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Siddham}"
 );
-assert(
-  /^\P{Script=Sidd}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sidd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sidd}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sidd}"
 );
-assert(
-  /^\P{sc=Siddham}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Siddham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Siddham}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Siddham}"
 );
-assert(
-  /^\P{sc=Sidd}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sidd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sidd}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sidd}"
 );

--- a/output/Script_-_SignWriting.js
+++ b/output/Script_-_SignWriting.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x01DAA1, 0x01DAAF]
   ]
 });
-assert(
-  /^\p{Script=SignWriting}+$/u.test(matchSymbols),
-  "`\\p{Script=SignWriting}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=SignWriting}+$/u,
+  matchSymbols,
+  "\\p{Script=SignWriting}"
 );
-assert(
-  /^\p{Script=Sgnw}+$/u.test(matchSymbols),
-  "`\\p{Script=Sgnw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sgnw}+$/u,
+  matchSymbols,
+  "\\p{Script=Sgnw}"
 );
-assert(
-  /^\p{sc=SignWriting}+$/u.test(matchSymbols),
-  "`\\p{sc=SignWriting}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=SignWriting}+$/u,
+  matchSymbols,
+  "\\p{sc=SignWriting}"
 );
-assert(
-  /^\p{sc=Sgnw}+$/u.test(matchSymbols),
-  "`\\p{sc=Sgnw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sgnw}+$/u,
+  matchSymbols,
+  "\\p{sc=Sgnw}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x01DAB0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=SignWriting}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=SignWriting}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=SignWriting}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=SignWriting}"
 );
-assert(
-  /^\P{Script=Sgnw}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sgnw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sgnw}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sgnw}"
 );
-assert(
-  /^\P{sc=SignWriting}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=SignWriting}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=SignWriting}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=SignWriting}"
 );
-assert(
-  /^\P{sc=Sgnw}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sgnw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sgnw}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sgnw}"
 );

--- a/output/Script_-_Sinhala.js
+++ b/output/Script_-_Sinhala.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -32,21 +32,25 @@ const matchSymbols = buildString({
     [0x0111E1, 0x0111F4]
   ]
 });
-assert(
-  /^\p{Script=Sinhala}+$/u.test(matchSymbols),
-  "`\\p{Script=Sinhala}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sinhala}+$/u,
+  matchSymbols,
+  "\\p{Script=Sinhala}"
 );
-assert(
-  /^\p{Script=Sinh}+$/u.test(matchSymbols),
-  "`\\p{Script=Sinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sinh}+$/u,
+  matchSymbols,
+  "\\p{Script=Sinh}"
 );
-assert(
-  /^\p{sc=Sinhala}+$/u.test(matchSymbols),
-  "`\\p{sc=Sinhala}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sinhala}+$/u,
+  matchSymbols,
+  "\\p{sc=Sinhala}"
 );
-assert(
-  /^\p{sc=Sinh}+$/u.test(matchSymbols),
-  "`\\p{sc=Sinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sinh}+$/u,
+  matchSymbols,
+  "\\p{sc=Sinh}"
 );
 
 const nonMatchSymbols = buildString({
@@ -71,19 +75,23 @@ const nonMatchSymbols = buildString({
     [0x0111F5, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Sinhala}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sinhala}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sinhala}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sinhala}"
 );
-assert(
-  /^\P{Script=Sinh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sinh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sinh}"
 );
-assert(
-  /^\P{sc=Sinhala}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sinhala}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sinhala}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sinhala}"
 );
-assert(
-  /^\P{sc=Sinh}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sinh}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sinh}"
 );

--- a/output/Script_-_Sora_Sompeng.js
+++ b/output/Script_-_Sora_Sompeng.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0110F0, 0x0110F9]
   ]
 });
-assert(
-  /^\p{Script=Sora_Sompeng}+$/u.test(matchSymbols),
-  "`\\p{Script=Sora_Sompeng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sora_Sompeng}+$/u,
+  matchSymbols,
+  "\\p{Script=Sora_Sompeng}"
 );
-assert(
-  /^\p{Script=Sora}+$/u.test(matchSymbols),
-  "`\\p{Script=Sora}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sora}+$/u,
+  matchSymbols,
+  "\\p{Script=Sora}"
 );
-assert(
-  /^\p{sc=Sora_Sompeng}+$/u.test(matchSymbols),
-  "`\\p{sc=Sora_Sompeng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sora_Sompeng}+$/u,
+  matchSymbols,
+  "\\p{sc=Sora_Sompeng}"
 );
-assert(
-  /^\p{sc=Sora}+$/u.test(matchSymbols),
-  "`\\p{sc=Sora}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sora}+$/u,
+  matchSymbols,
+  "\\p{sc=Sora}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0110FA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Sora_Sompeng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sora_Sompeng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sora_Sompeng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sora_Sompeng}"
 );
-assert(
-  /^\P{Script=Sora}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sora}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sora}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sora}"
 );
-assert(
-  /^\P{sc=Sora_Sompeng}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sora_Sompeng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sora_Sompeng}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sora_Sompeng}"
 );
-assert(
-  /^\P{sc=Sora}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sora}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sora}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sora}"
 );

--- a/output/Script_-_Sundanese.js
+++ b/output/Script_-_Sundanese.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x001CC0, 0x001CC7]
   ]
 });
-assert(
-  /^\p{Script=Sundanese}+$/u.test(matchSymbols),
-  "`\\p{Script=Sundanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sundanese}+$/u,
+  matchSymbols,
+  "\\p{Script=Sundanese}"
 );
-assert(
-  /^\p{Script=Sund}+$/u.test(matchSymbols),
-  "`\\p{Script=Sund}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sund}+$/u,
+  matchSymbols,
+  "\\p{Script=Sund}"
 );
-assert(
-  /^\p{sc=Sundanese}+$/u.test(matchSymbols),
-  "`\\p{sc=Sundanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sundanese}+$/u,
+  matchSymbols,
+  "\\p{sc=Sundanese}"
 );
-assert(
-  /^\p{sc=Sund}+$/u.test(matchSymbols),
-  "`\\p{sc=Sund}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sund}+$/u,
+  matchSymbols,
+  "\\p{sc=Sund}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Sundanese}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sundanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sundanese}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sundanese}"
 );
-assert(
-  /^\P{Script=Sund}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sund}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sund}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sund}"
 );
-assert(
-  /^\P{sc=Sundanese}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sundanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sundanese}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sundanese}"
 );
-assert(
-  /^\P{sc=Sund}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sund}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sund}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sund}"
 );

--- a/output/Script_-_Syloti_Nagri.js
+++ b/output/Script_-_Syloti_Nagri.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x00A800, 0x00A82B]
   ]
 });
-assert(
-  /^\p{Script=Syloti_Nagri}+$/u.test(matchSymbols),
-  "`\\p{Script=Syloti_Nagri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Syloti_Nagri}+$/u,
+  matchSymbols,
+  "\\p{Script=Syloti_Nagri}"
 );
-assert(
-  /^\p{Script=Sylo}+$/u.test(matchSymbols),
-  "`\\p{Script=Sylo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Sylo}+$/u,
+  matchSymbols,
+  "\\p{Script=Sylo}"
 );
-assert(
-  /^\p{sc=Syloti_Nagri}+$/u.test(matchSymbols),
-  "`\\p{sc=Syloti_Nagri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Syloti_Nagri}+$/u,
+  matchSymbols,
+  "\\p{sc=Syloti_Nagri}"
 );
-assert(
-  /^\p{sc=Sylo}+$/u.test(matchSymbols),
-  "`\\p{sc=Sylo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Sylo}+$/u,
+  matchSymbols,
+  "\\p{sc=Sylo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Syloti_Nagri}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Syloti_Nagri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Syloti_Nagri}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Syloti_Nagri}"
 );
-assert(
-  /^\P{Script=Sylo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Sylo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Sylo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Sylo}"
 );
-assert(
-  /^\P{sc=Syloti_Nagri}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Syloti_Nagri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Syloti_Nagri}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Syloti_Nagri}"
 );
-assert(
-  /^\P{sc=Sylo}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Sylo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Sylo}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Sylo}"
 );

--- a/output/Script_-_Syriac.js
+++ b/output/Script_-_Syriac.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00074D, 0x00074F]
   ]
 });
-assert(
-  /^\p{Script=Syriac}+$/u.test(matchSymbols),
-  "`\\p{Script=Syriac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Syriac}+$/u,
+  matchSymbols,
+  "\\p{Script=Syriac}"
 );
-assert(
-  /^\p{Script=Syrc}+$/u.test(matchSymbols),
-  "`\\p{Script=Syrc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Syrc}+$/u,
+  matchSymbols,
+  "\\p{Script=Syrc}"
 );
-assert(
-  /^\p{sc=Syriac}+$/u.test(matchSymbols),
-  "`\\p{sc=Syriac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Syriac}+$/u,
+  matchSymbols,
+  "\\p{sc=Syriac}"
 );
-assert(
-  /^\p{sc=Syrc}+$/u.test(matchSymbols),
-  "`\\p{sc=Syrc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Syrc}+$/u,
+  matchSymbols,
+  "\\p{sc=Syrc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Syriac}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Syriac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Syriac}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Syriac}"
 );
-assert(
-  /^\P{Script=Syrc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Syrc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Syrc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Syrc}"
 );
-assert(
-  /^\P{sc=Syriac}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Syriac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Syriac}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Syriac}"
 );
-assert(
-  /^\P{sc=Syrc}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Syrc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Syrc}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Syrc}"
 );

--- a/output/Script_-_Tagalog.js
+++ b/output/Script_-_Tagalog.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x00170E, 0x001714]
   ]
 });
-assert(
-  /^\p{Script=Tagalog}+$/u.test(matchSymbols),
-  "`\\p{Script=Tagalog}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tagalog}+$/u,
+  matchSymbols,
+  "\\p{Script=Tagalog}"
 );
-assert(
-  /^\p{Script=Tglg}+$/u.test(matchSymbols),
-  "`\\p{Script=Tglg}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tglg}+$/u,
+  matchSymbols,
+  "\\p{Script=Tglg}"
 );
-assert(
-  /^\p{sc=Tagalog}+$/u.test(matchSymbols),
-  "`\\p{sc=Tagalog}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tagalog}+$/u,
+  matchSymbols,
+  "\\p{sc=Tagalog}"
 );
-assert(
-  /^\p{sc=Tglg}+$/u.test(matchSymbols),
-  "`\\p{sc=Tglg}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tglg}+$/u,
+  matchSymbols,
+  "\\p{sc=Tglg}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tagalog}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tagalog}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tagalog}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tagalog}"
 );
-assert(
-  /^\P{Script=Tglg}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tglg}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tglg}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tglg}"
 );
-assert(
-  /^\P{sc=Tagalog}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tagalog}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tagalog}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tagalog}"
 );
-assert(
-  /^\P{sc=Tglg}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tglg}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tglg}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tglg}"
 );

--- a/output/Script_-_Tagbanwa.js
+++ b/output/Script_-_Tagbanwa.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x001772, 0x001773]
   ]
 });
-assert(
-  /^\p{Script=Tagbanwa}+$/u.test(matchSymbols),
-  "`\\p{Script=Tagbanwa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tagbanwa}+$/u,
+  matchSymbols,
+  "\\p{Script=Tagbanwa}"
 );
-assert(
-  /^\p{Script=Tagb}+$/u.test(matchSymbols),
-  "`\\p{Script=Tagb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tagb}+$/u,
+  matchSymbols,
+  "\\p{Script=Tagb}"
 );
-assert(
-  /^\p{sc=Tagbanwa}+$/u.test(matchSymbols),
-  "`\\p{sc=Tagbanwa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tagbanwa}+$/u,
+  matchSymbols,
+  "\\p{sc=Tagbanwa}"
 );
-assert(
-  /^\p{sc=Tagb}+$/u.test(matchSymbols),
-  "`\\p{sc=Tagb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tagb}+$/u,
+  matchSymbols,
+  "\\p{sc=Tagb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tagbanwa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tagbanwa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tagbanwa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tagbanwa}"
 );
-assert(
-  /^\P{Script=Tagb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tagb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tagb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tagb}"
 );
-assert(
-  /^\P{sc=Tagbanwa}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tagbanwa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tagbanwa}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tagbanwa}"
 );
-assert(
-  /^\P{sc=Tagb}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tagb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tagb}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tagb}"
 );

--- a/output/Script_-_Tai_Le.js
+++ b/output/Script_-_Tai_Le.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x001970, 0x001974]
   ]
 });
-assert(
-  /^\p{Script=Tai_Le}+$/u.test(matchSymbols),
-  "`\\p{Script=Tai_Le}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tai_Le}+$/u,
+  matchSymbols,
+  "\\p{Script=Tai_Le}"
 );
-assert(
-  /^\p{Script=Tale}+$/u.test(matchSymbols),
-  "`\\p{Script=Tale}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tale}+$/u,
+  matchSymbols,
+  "\\p{Script=Tale}"
 );
-assert(
-  /^\p{sc=Tai_Le}+$/u.test(matchSymbols),
-  "`\\p{sc=Tai_Le}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tai_Le}+$/u,
+  matchSymbols,
+  "\\p{sc=Tai_Le}"
 );
-assert(
-  /^\p{sc=Tale}+$/u.test(matchSymbols),
-  "`\\p{sc=Tale}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tale}+$/u,
+  matchSymbols,
+  "\\p{sc=Tale}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tai_Le}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tai_Le}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tai_Le}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tai_Le}"
 );
-assert(
-  /^\P{Script=Tale}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tale}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tale}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tale}"
 );
-assert(
-  /^\P{sc=Tai_Le}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tai_Le}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tai_Le}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tai_Le}"
 );
-assert(
-  /^\P{sc=Tale}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tale}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tale}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tale}"
 );

--- a/output/Script_-_Tai_Tham.js
+++ b/output/Script_-_Tai_Tham.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x001AA0, 0x001AAD]
   ]
 });
-assert(
-  /^\p{Script=Tai_Tham}+$/u.test(matchSymbols),
-  "`\\p{Script=Tai_Tham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tai_Tham}+$/u,
+  matchSymbols,
+  "\\p{Script=Tai_Tham}"
 );
-assert(
-  /^\p{Script=Lana}+$/u.test(matchSymbols),
-  "`\\p{Script=Lana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Lana}+$/u,
+  matchSymbols,
+  "\\p{Script=Lana}"
 );
-assert(
-  /^\p{sc=Tai_Tham}+$/u.test(matchSymbols),
-  "`\\p{sc=Tai_Tham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tai_Tham}+$/u,
+  matchSymbols,
+  "\\p{sc=Tai_Tham}"
 );
-assert(
-  /^\p{sc=Lana}+$/u.test(matchSymbols),
-  "`\\p{sc=Lana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Lana}+$/u,
+  matchSymbols,
+  "\\p{sc=Lana}"
 );
 
 const nonMatchSymbols = buildString({
@@ -54,19 +58,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tai_Tham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tai_Tham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tai_Tham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tai_Tham}"
 );
-assert(
-  /^\P{Script=Lana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Lana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Lana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Lana}"
 );
-assert(
-  /^\P{sc=Tai_Tham}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tai_Tham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tai_Tham}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tai_Tham}"
 );
-assert(
-  /^\P{sc=Lana}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Lana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Lana}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Lana}"
 );

--- a/output/Script_-_Tai_Viet.js
+++ b/output/Script_-_Tai_Viet.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x00AADB, 0x00AADF]
   ]
 });
-assert(
-  /^\p{Script=Tai_Viet}+$/u.test(matchSymbols),
-  "`\\p{Script=Tai_Viet}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tai_Viet}+$/u,
+  matchSymbols,
+  "\\p{Script=Tai_Viet}"
 );
-assert(
-  /^\p{Script=Tavt}+$/u.test(matchSymbols),
-  "`\\p{Script=Tavt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tavt}+$/u,
+  matchSymbols,
+  "\\p{Script=Tavt}"
 );
-assert(
-  /^\p{sc=Tai_Viet}+$/u.test(matchSymbols),
-  "`\\p{sc=Tai_Viet}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tai_Viet}+$/u,
+  matchSymbols,
+  "\\p{sc=Tai_Viet}"
 );
-assert(
-  /^\p{sc=Tavt}+$/u.test(matchSymbols),
-  "`\\p{sc=Tavt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tavt}+$/u,
+  matchSymbols,
+  "\\p{sc=Tavt}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tai_Viet}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tai_Viet}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tai_Viet}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tai_Viet}"
 );
-assert(
-  /^\P{Script=Tavt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tavt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tavt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tavt}"
 );
-assert(
-  /^\P{sc=Tai_Viet}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tai_Viet}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tai_Viet}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tai_Viet}"
 );
-assert(
-  /^\P{sc=Tavt}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tavt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tavt}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tavt}"
 );

--- a/output/Script_-_Takri.js
+++ b/output/Script_-_Takri.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0116C0, 0x0116C9]
   ]
 });
-assert(
-  /^\p{Script=Takri}+$/u.test(matchSymbols),
-  "`\\p{Script=Takri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Takri}+$/u,
+  matchSymbols,
+  "\\p{Script=Takri}"
 );
-assert(
-  /^\p{Script=Takr}+$/u.test(matchSymbols),
-  "`\\p{Script=Takr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Takr}+$/u,
+  matchSymbols,
+  "\\p{Script=Takr}"
 );
-assert(
-  /^\p{sc=Takri}+$/u.test(matchSymbols),
-  "`\\p{sc=Takri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Takri}+$/u,
+  matchSymbols,
+  "\\p{sc=Takri}"
 );
-assert(
-  /^\p{sc=Takr}+$/u.test(matchSymbols),
-  "`\\p{sc=Takr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Takr}+$/u,
+  matchSymbols,
+  "\\p{sc=Takr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0116CA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Takri}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Takri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Takri}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Takri}"
 );
-assert(
-  /^\P{Script=Takr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Takr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Takr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Takr}"
 );
-assert(
-  /^\P{sc=Takri}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Takri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Takri}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Takri}"
 );
-assert(
-  /^\P{sc=Takr}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Takr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Takr}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Takr}"
 );

--- a/output/Script_-_Tamil.js
+++ b/output/Script_-_Tamil.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -35,21 +35,25 @@ const matchSymbols = buildString({
     [0x000BE6, 0x000BFA]
   ]
 });
-assert(
-  /^\p{Script=Tamil}+$/u.test(matchSymbols),
-  "`\\p{Script=Tamil}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tamil}+$/u,
+  matchSymbols,
+  "\\p{Script=Tamil}"
 );
-assert(
-  /^\p{Script=Taml}+$/u.test(matchSymbols),
-  "`\\p{Script=Taml}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Taml}+$/u,
+  matchSymbols,
+  "\\p{Script=Taml}"
 );
-assert(
-  /^\p{sc=Tamil}+$/u.test(matchSymbols),
-  "`\\p{sc=Tamil}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tamil}+$/u,
+  matchSymbols,
+  "\\p{sc=Tamil}"
 );
-assert(
-  /^\p{sc=Taml}+$/u.test(matchSymbols),
-  "`\\p{sc=Taml}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Taml}+$/u,
+  matchSymbols,
+  "\\p{sc=Taml}"
 );
 
 const nonMatchSymbols = buildString({
@@ -77,19 +81,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tamil}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tamil}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tamil}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tamil}"
 );
-assert(
-  /^\P{Script=Taml}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Taml}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Taml}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Taml}"
 );
-assert(
-  /^\P{sc=Tamil}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tamil}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tamil}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tamil}"
 );
-assert(
-  /^\P{sc=Taml}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Taml}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Taml}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Taml}"
 );

--- a/output/Script_-_Tangut.js
+++ b/output/Script_-_Tangut.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x018800, 0x018AF2]
   ]
 });
-assert(
-  /^\p{Script=Tangut}+$/u.test(matchSymbols),
-  "`\\p{Script=Tangut}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tangut}+$/u,
+  matchSymbols,
+  "\\p{Script=Tangut}"
 );
-assert(
-  /^\p{Script=Tang}+$/u.test(matchSymbols),
-  "`\\p{Script=Tang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tang}+$/u,
+  matchSymbols,
+  "\\p{Script=Tang}"
 );
-assert(
-  /^\p{sc=Tangut}+$/u.test(matchSymbols),
-  "`\\p{sc=Tangut}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tangut}+$/u,
+  matchSymbols,
+  "\\p{sc=Tangut}"
 );
-assert(
-  /^\p{sc=Tang}+$/u.test(matchSymbols),
-  "`\\p{sc=Tang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tang}+$/u,
+  matchSymbols,
+  "\\p{sc=Tang}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x018AF3, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tangut}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tangut}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tangut}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tangut}"
 );
-assert(
-  /^\P{Script=Tang}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tang}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tang}"
 );
-assert(
-  /^\P{sc=Tangut}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tangut}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tangut}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tangut}"
 );
-assert(
-  /^\P{sc=Tang}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tang}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tang}"
 );

--- a/output/Script_-_Telugu.js
+++ b/output/Script_-_Telugu.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -31,21 +31,25 @@ const matchSymbols = buildString({
     [0x000C78, 0x000C7F]
   ]
 });
-assert(
-  /^\p{Script=Telugu}+$/u.test(matchSymbols),
-  "`\\p{Script=Telugu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Telugu}+$/u,
+  matchSymbols,
+  "\\p{Script=Telugu}"
 );
-assert(
-  /^\p{Script=Telu}+$/u.test(matchSymbols),
-  "`\\p{Script=Telu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Telu}+$/u,
+  matchSymbols,
+  "\\p{Script=Telu}"
 );
-assert(
-  /^\p{sc=Telugu}+$/u.test(matchSymbols),
-  "`\\p{sc=Telugu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Telugu}+$/u,
+  matchSymbols,
+  "\\p{sc=Telugu}"
 );
-assert(
-  /^\p{sc=Telu}+$/u.test(matchSymbols),
-  "`\\p{sc=Telu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Telu}+$/u,
+  matchSymbols,
+  "\\p{sc=Telu}"
 );
 
 const nonMatchSymbols = buildString({
@@ -70,19 +74,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Telugu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Telugu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Telugu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Telugu}"
 );
-assert(
-  /^\P{Script=Telu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Telu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Telu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Telu}"
 );
-assert(
-  /^\P{sc=Telugu}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Telugu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Telugu}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Telugu}"
 );
-assert(
-  /^\P{sc=Telu}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Telu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Telu}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Telu}"
 );

--- a/output/Script_-_Thaana.js
+++ b/output/Script_-_Thaana.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x000780, 0x0007B1]
   ]
 });
-assert(
-  /^\p{Script=Thaana}+$/u.test(matchSymbols),
-  "`\\p{Script=Thaana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Thaana}+$/u,
+  matchSymbols,
+  "\\p{Script=Thaana}"
 );
-assert(
-  /^\p{Script=Thaa}+$/u.test(matchSymbols),
-  "`\\p{Script=Thaa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Thaa}+$/u,
+  matchSymbols,
+  "\\p{Script=Thaa}"
 );
-assert(
-  /^\p{sc=Thaana}+$/u.test(matchSymbols),
-  "`\\p{sc=Thaana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Thaana}+$/u,
+  matchSymbols,
+  "\\p{sc=Thaana}"
 );
-assert(
-  /^\p{sc=Thaa}+$/u.test(matchSymbols),
-  "`\\p{sc=Thaa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Thaa}+$/u,
+  matchSymbols,
+  "\\p{sc=Thaa}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Thaana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Thaana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Thaana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Thaana}"
 );
-assert(
-  /^\P{Script=Thaa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Thaa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Thaa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Thaa}"
 );
-assert(
-  /^\P{sc=Thaana}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Thaana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Thaana}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Thaana}"
 );
-assert(
-  /^\P{sc=Thaa}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Thaa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Thaa}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Thaa}"
 );

--- a/output/Script_-_Thai.js
+++ b/output/Script_-_Thai.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x000E40, 0x000E5B]
   ]
 });
-assert(
-  /^\p{Script=Thai}+$/u.test(matchSymbols),
-  "`\\p{Script=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Thai}+$/u,
+  matchSymbols,
+  "\\p{Script=Thai}"
 );
-assert(
-  /^\p{Script=Thai}+$/u.test(matchSymbols),
-  "`\\p{Script=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Thai}+$/u,
+  matchSymbols,
+  "\\p{Script=Thai}"
 );
-assert(
-  /^\p{sc=Thai}+$/u.test(matchSymbols),
-  "`\\p{sc=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Thai}+$/u,
+  matchSymbols,
+  "\\p{sc=Thai}"
 );
-assert(
-  /^\p{sc=Thai}+$/u.test(matchSymbols),
-  "`\\p{sc=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Thai}+$/u,
+  matchSymbols,
+  "\\p{sc=Thai}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Thai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Thai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Thai}"
 );
-assert(
-  /^\P{Script=Thai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Thai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Thai}"
 );
-assert(
-  /^\P{sc=Thai}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Thai}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Thai}"
 );
-assert(
-  /^\P{sc=Thai}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Thai}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Thai}"
 );

--- a/output/Script_-_Tibetan.js
+++ b/output/Script_-_Tibetan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,21 +25,25 @@ const matchSymbols = buildString({
     [0x000FD9, 0x000FDA]
   ]
 });
-assert(
-  /^\p{Script=Tibetan}+$/u.test(matchSymbols),
-  "`\\p{Script=Tibetan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tibetan}+$/u,
+  matchSymbols,
+  "\\p{Script=Tibetan}"
 );
-assert(
-  /^\p{Script=Tibt}+$/u.test(matchSymbols),
-  "`\\p{Script=Tibt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tibt}+$/u,
+  matchSymbols,
+  "\\p{Script=Tibt}"
 );
-assert(
-  /^\p{sc=Tibetan}+$/u.test(matchSymbols),
-  "`\\p{sc=Tibetan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tibetan}+$/u,
+  matchSymbols,
+  "\\p{sc=Tibetan}"
 );
-assert(
-  /^\p{sc=Tibt}+$/u.test(matchSymbols),
-  "`\\p{sc=Tibt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tibt}+$/u,
+  matchSymbols,
+  "\\p{sc=Tibt}"
 );
 
 const nonMatchSymbols = buildString({
@@ -58,19 +62,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tibetan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tibetan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tibetan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tibetan}"
 );
-assert(
-  /^\P{Script=Tibt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tibt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tibt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tibt}"
 );
-assert(
-  /^\P{sc=Tibetan}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tibetan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tibetan}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tibetan}"
 );
-assert(
-  /^\P{sc=Tibt}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tibt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tibt}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tibt}"
 );

--- a/output/Script_-_Tifinagh.js
+++ b/output/Script_-_Tifinagh.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x002D6F, 0x002D70]
   ]
 });
-assert(
-  /^\p{Script=Tifinagh}+$/u.test(matchSymbols),
-  "`\\p{Script=Tifinagh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tifinagh}+$/u,
+  matchSymbols,
+  "\\p{Script=Tifinagh}"
 );
-assert(
-  /^\p{Script=Tfng}+$/u.test(matchSymbols),
-  "`\\p{Script=Tfng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tfng}+$/u,
+  matchSymbols,
+  "\\p{Script=Tfng}"
 );
-assert(
-  /^\p{sc=Tifinagh}+$/u.test(matchSymbols),
-  "`\\p{sc=Tifinagh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tifinagh}+$/u,
+  matchSymbols,
+  "\\p{sc=Tifinagh}"
 );
-assert(
-  /^\p{sc=Tfng}+$/u.test(matchSymbols),
-  "`\\p{sc=Tfng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tfng}+$/u,
+  matchSymbols,
+  "\\p{sc=Tfng}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tifinagh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tifinagh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tifinagh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tifinagh}"
 );
-assert(
-  /^\P{Script=Tfng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tfng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tfng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tfng}"
 );
-assert(
-  /^\P{sc=Tifinagh}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tifinagh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tifinagh}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tifinagh}"
 );
-assert(
-  /^\P{sc=Tfng}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tfng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tfng}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tfng}"
 );

--- a/output/Script_-_Tirhuta.js
+++ b/output/Script_-_Tirhuta.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0114D0, 0x0114D9]
   ]
 });
-assert(
-  /^\p{Script=Tirhuta}+$/u.test(matchSymbols),
-  "`\\p{Script=Tirhuta}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tirhuta}+$/u,
+  matchSymbols,
+  "\\p{Script=Tirhuta}"
 );
-assert(
-  /^\p{Script=Tirh}+$/u.test(matchSymbols),
-  "`\\p{Script=Tirh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Tirh}+$/u,
+  matchSymbols,
+  "\\p{Script=Tirh}"
 );
-assert(
-  /^\p{sc=Tirhuta}+$/u.test(matchSymbols),
-  "`\\p{sc=Tirhuta}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tirhuta}+$/u,
+  matchSymbols,
+  "\\p{sc=Tirhuta}"
 );
-assert(
-  /^\p{sc=Tirh}+$/u.test(matchSymbols),
-  "`\\p{sc=Tirh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Tirh}+$/u,
+  matchSymbols,
+  "\\p{sc=Tirh}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0114DA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Tirhuta}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tirhuta}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tirhuta}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tirhuta}"
 );
-assert(
-  /^\P{Script=Tirh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Tirh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Tirh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Tirh}"
 );
-assert(
-  /^\P{sc=Tirhuta}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tirhuta}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tirhuta}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tirhuta}"
 );
-assert(
-  /^\P{sc=Tirh}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Tirh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Tirh}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Tirh}"
 );

--- a/output/Script_-_Ugaritic.js
+++ b/output/Script_-_Ugaritic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010380, 0x01039D]
   ]
 });
-assert(
-  /^\p{Script=Ugaritic}+$/u.test(matchSymbols),
-  "`\\p{Script=Ugaritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ugaritic}+$/u,
+  matchSymbols,
+  "\\p{Script=Ugaritic}"
 );
-assert(
-  /^\p{Script=Ugar}+$/u.test(matchSymbols),
-  "`\\p{Script=Ugar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Ugar}+$/u,
+  matchSymbols,
+  "\\p{Script=Ugar}"
 );
-assert(
-  /^\p{sc=Ugaritic}+$/u.test(matchSymbols),
-  "`\\p{sc=Ugaritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ugaritic}+$/u,
+  matchSymbols,
+  "\\p{sc=Ugaritic}"
 );
-assert(
-  /^\p{sc=Ugar}+$/u.test(matchSymbols),
-  "`\\p{sc=Ugar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Ugar}+$/u,
+  matchSymbols,
+  "\\p{sc=Ugar}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x0103A0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Ugaritic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ugaritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ugaritic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ugaritic}"
 );
-assert(
-  /^\P{Script=Ugar}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Ugar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Ugar}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Ugar}"
 );
-assert(
-  /^\P{sc=Ugaritic}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ugaritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ugaritic}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ugaritic}"
 );
-assert(
-  /^\P{sc=Ugar}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Ugar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Ugar}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Ugar}"
 );

--- a/output/Script_-_Vai.js
+++ b/output/Script_-_Vai.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x00A500, 0x00A62B]
   ]
 });
-assert(
-  /^\p{Script=Vai}+$/u.test(matchSymbols),
-  "`\\p{Script=Vai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Vai}+$/u,
+  matchSymbols,
+  "\\p{Script=Vai}"
 );
-assert(
-  /^\p{Script=Vaii}+$/u.test(matchSymbols),
-  "`\\p{Script=Vaii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Vaii}+$/u,
+  matchSymbols,
+  "\\p{Script=Vaii}"
 );
-assert(
-  /^\p{sc=Vai}+$/u.test(matchSymbols),
-  "`\\p{sc=Vai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Vai}+$/u,
+  matchSymbols,
+  "\\p{sc=Vai}"
 );
-assert(
-  /^\p{sc=Vaii}+$/u.test(matchSymbols),
-  "`\\p{sc=Vaii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Vaii}+$/u,
+  matchSymbols,
+  "\\p{sc=Vaii}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Vai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Vai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Vai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Vai}"
 );
-assert(
-  /^\P{Script=Vaii}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Vaii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Vaii}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Vaii}"
 );
-assert(
-  /^\P{sc=Vai}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Vai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Vai}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Vai}"
 );
-assert(
-  /^\P{sc=Vaii}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Vaii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Vaii}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Vaii}"
 );

--- a/output/Script_-_Warang_Citi.js
+++ b/output/Script_-_Warang_Citi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x0118A0, 0x0118F2]
   ]
 });
-assert(
-  /^\p{Script=Warang_Citi}+$/u.test(matchSymbols),
-  "`\\p{Script=Warang_Citi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Warang_Citi}+$/u,
+  matchSymbols,
+  "\\p{Script=Warang_Citi}"
 );
-assert(
-  /^\p{Script=Wara}+$/u.test(matchSymbols),
-  "`\\p{Script=Wara}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Wara}+$/u,
+  matchSymbols,
+  "\\p{Script=Wara}"
 );
-assert(
-  /^\p{sc=Warang_Citi}+$/u.test(matchSymbols),
-  "`\\p{sc=Warang_Citi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Warang_Citi}+$/u,
+  matchSymbols,
+  "\\p{sc=Warang_Citi}"
 );
-assert(
-  /^\p{sc=Wara}+$/u.test(matchSymbols),
-  "`\\p{sc=Wara}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Wara}+$/u,
+  matchSymbols,
+  "\\p{sc=Wara}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x011900, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Warang_Citi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Warang_Citi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Warang_Citi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Warang_Citi}"
 );
-assert(
-  /^\P{Script=Wara}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Wara}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Wara}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Wara}"
 );
-assert(
-  /^\P{sc=Warang_Citi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Warang_Citi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Warang_Citi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Warang_Citi}"
 );
-assert(
-  /^\P{sc=Wara}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Wara}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Wara}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Wara}"
 );

--- a/output/Script_-_Yi.js
+++ b/output/Script_-_Yi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x00A490, 0x00A4C6]
   ]
 });
-assert(
-  /^\p{Script=Yi}+$/u.test(matchSymbols),
-  "`\\p{Script=Yi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Yi}+$/u,
+  matchSymbols,
+  "\\p{Script=Yi}"
 );
-assert(
-  /^\p{Script=Yiii}+$/u.test(matchSymbols),
-  "`\\p{Script=Yiii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script=Yiii}+$/u,
+  matchSymbols,
+  "\\p{Script=Yiii}"
 );
-assert(
-  /^\p{sc=Yi}+$/u.test(matchSymbols),
-  "`\\p{sc=Yi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Yi}+$/u,
+  matchSymbols,
+  "\\p{sc=Yi}"
 );
-assert(
-  /^\p{sc=Yiii}+$/u.test(matchSymbols),
-  "`\\p{sc=Yiii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{sc=Yiii}+$/u,
+  matchSymbols,
+  "\\p{sc=Yiii}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script=Yi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Yi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Yi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Yi}"
 );
-assert(
-  /^\P{Script=Yiii}+$/u.test(nonMatchSymbols),
-  "`\\P{Script=Yiii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script=Yiii}+$/u,
+  nonMatchSymbols,
+  "\\P{Script=Yiii}"
 );
-assert(
-  /^\P{sc=Yi}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Yi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Yi}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Yi}"
 );
-assert(
-  /^\P{sc=Yiii}+$/u.test(nonMatchSymbols),
-  "`\\P{sc=Yiii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{sc=Yiii}+$/u,
+  nonMatchSymbols,
+  "\\P{sc=Yiii}"
 );

--- a/output/Script_Extensions_-_Adlam.js
+++ b/output/Script_Extensions_-_Adlam.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x01E95E, 0x01E95F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Adlam}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Adlam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Adlam}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Adlam}"
 );
-assert(
-  /^\p{Script_Extensions=Adlm}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Adlm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Adlm}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Adlm}"
 );
-assert(
-  /^\p{scx=Adlam}+$/u.test(matchSymbols),
-  "`\\p{scx=Adlam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Adlam}+$/u,
+  matchSymbols,
+  "\\p{scx=Adlam}"
 );
-assert(
-  /^\p{scx=Adlm}+$/u.test(matchSymbols),
-  "`\\p{scx=Adlm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Adlm}+$/u,
+  matchSymbols,
+  "\\p{scx=Adlm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x01E960, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Adlam}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Adlam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Adlam}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Adlam}"
 );
-assert(
-  /^\P{Script_Extensions=Adlm}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Adlm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Adlm}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Adlm}"
 );
-assert(
-  /^\P{scx=Adlam}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Adlam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Adlam}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Adlam}"
 );
-assert(
-  /^\P{scx=Adlm}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Adlm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Adlm}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Adlm}"
 );

--- a/output/Script_Extensions_-_Ahom.js
+++ b/output/Script_Extensions_-_Ahom.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x011730, 0x01173F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Ahom}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ahom}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ahom}"
 );
-assert(
-  /^\p{Script_Extensions=Ahom}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ahom}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ahom}"
 );
-assert(
-  /^\p{scx=Ahom}+$/u.test(matchSymbols),
-  "`\\p{scx=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ahom}+$/u,
+  matchSymbols,
+  "\\p{scx=Ahom}"
 );
-assert(
-  /^\p{scx=Ahom}+$/u.test(matchSymbols),
-  "`\\p{scx=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ahom}+$/u,
+  matchSymbols,
+  "\\p{scx=Ahom}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x011740, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Ahom}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ahom}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ahom}"
 );
-assert(
-  /^\P{Script_Extensions=Ahom}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ahom}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ahom}"
 );
-assert(
-  /^\P{scx=Ahom}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ahom}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ahom}"
 );
-assert(
-  /^\P{scx=Ahom}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ahom}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ahom}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ahom}"
 );

--- a/output/Script_Extensions_-_Anatolian_Hieroglyphs.js
+++ b/output/Script_Extensions_-_Anatolian_Hieroglyphs.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x014400, 0x014646]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Anatolian_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Anatolian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Anatolian_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Anatolian_Hieroglyphs}"
 );
-assert(
-  /^\p{Script_Extensions=Hluw}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hluw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hluw}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hluw}"
 );
-assert(
-  /^\p{scx=Anatolian_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{scx=Anatolian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Anatolian_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{scx=Anatolian_Hieroglyphs}"
 );
-assert(
-  /^\p{scx=Hluw}+$/u.test(matchSymbols),
-  "`\\p{scx=Hluw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hluw}+$/u,
+  matchSymbols,
+  "\\p{scx=Hluw}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x014647, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Anatolian_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Anatolian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Anatolian_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Anatolian_Hieroglyphs}"
 );
-assert(
-  /^\P{Script_Extensions=Hluw}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hluw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hluw}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hluw}"
 );
-assert(
-  /^\P{scx=Anatolian_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Anatolian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Anatolian_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Anatolian_Hieroglyphs}"
 );
-assert(
-  /^\P{scx=Hluw}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hluw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hluw}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hluw}"
 );

--- a/output/Script_Extensions_-_Arabic.js
+++ b/output/Script_Extensions_-_Arabic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -71,21 +71,25 @@ const matchSymbols = buildString({
     [0x01EEF0, 0x01EEF1]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Arabic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Arabic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Arabic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Arabic}"
 );
-assert(
-  /^\p{Script_Extensions=Arab}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Arab}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Arab}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Arab}"
 );
-assert(
-  /^\p{scx=Arabic}+$/u.test(matchSymbols),
-  "`\\p{scx=Arabic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Arabic}+$/u,
+  matchSymbols,
+  "\\p{scx=Arabic}"
 );
-assert(
-  /^\p{scx=Arab}+$/u.test(matchSymbols),
-  "`\\p{scx=Arab}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Arab}+$/u,
+  matchSymbols,
+  "\\p{scx=Arab}"
 );
 
 const nonMatchSymbols = buildString({
@@ -149,19 +153,23 @@ const nonMatchSymbols = buildString({
     [0x01EEF2, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Arabic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Arabic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Arabic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Arabic}"
 );
-assert(
-  /^\P{Script_Extensions=Arab}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Arab}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Arab}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Arab}"
 );
-assert(
-  /^\P{scx=Arabic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Arabic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Arabic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Arabic}"
 );
-assert(
-  /^\P{scx=Arab}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Arab}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Arab}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Arab}"
 );

--- a/output/Script_Extensions_-_Armenian.js
+++ b/output/Script_Extensions_-_Armenian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -24,21 +24,25 @@ const matchSymbols = buildString({
     [0x00FB13, 0x00FB17]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Armenian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Armenian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Armenian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Armenian}"
 );
-assert(
-  /^\p{Script_Extensions=Armn}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Armn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Armn}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Armn}"
 );
-assert(
-  /^\p{scx=Armenian}+$/u.test(matchSymbols),
-  "`\\p{scx=Armenian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Armenian}+$/u,
+  matchSymbols,
+  "\\p{scx=Armenian}"
 );
-assert(
-  /^\p{scx=Armn}+$/u.test(matchSymbols),
-  "`\\p{scx=Armn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Armn}+$/u,
+  matchSymbols,
+  "\\p{scx=Armn}"
 );
 
 const nonMatchSymbols = buildString({
@@ -56,19 +60,23 @@ const nonMatchSymbols = buildString({
     [0x00FB18, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Armenian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Armenian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Armenian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Armenian}"
 );
-assert(
-  /^\P{Script_Extensions=Armn}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Armn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Armn}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Armn}"
 );
-assert(
-  /^\P{scx=Armenian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Armenian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Armenian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Armenian}"
 );
-assert(
-  /^\P{scx=Armn}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Armn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Armn}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Armn}"
 );

--- a/output/Script_Extensions_-_Avestan.js
+++ b/output/Script_Extensions_-_Avestan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x010B39, 0x010B3F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Avestan}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Avestan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Avestan}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Avestan}"
 );
-assert(
-  /^\p{Script_Extensions=Avst}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Avst}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Avst}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Avst}"
 );
-assert(
-  /^\p{scx=Avestan}+$/u.test(matchSymbols),
-  "`\\p{scx=Avestan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Avestan}+$/u,
+  matchSymbols,
+  "\\p{scx=Avestan}"
 );
-assert(
-  /^\p{scx=Avst}+$/u.test(matchSymbols),
-  "`\\p{scx=Avst}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Avst}+$/u,
+  matchSymbols,
+  "\\p{scx=Avst}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x010B40, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Avestan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Avestan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Avestan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Avestan}"
 );
-assert(
-  /^\P{Script_Extensions=Avst}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Avst}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Avst}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Avst}"
 );
-assert(
-  /^\P{scx=Avestan}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Avestan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Avestan}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Avestan}"
 );
-assert(
-  /^\P{scx=Avst}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Avst}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Avst}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Avst}"
 );

--- a/output/Script_Extensions_-_Balinese.js
+++ b/output/Script_Extensions_-_Balinese.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x001B50, 0x001B7C]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Balinese}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Balinese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Balinese}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Balinese}"
 );
-assert(
-  /^\p{Script_Extensions=Bali}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bali}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bali}"
 );
-assert(
-  /^\p{scx=Balinese}+$/u.test(matchSymbols),
-  "`\\p{scx=Balinese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Balinese}+$/u,
+  matchSymbols,
+  "\\p{scx=Balinese}"
 );
-assert(
-  /^\p{scx=Bali}+$/u.test(matchSymbols),
-  "`\\p{scx=Bali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bali}+$/u,
+  matchSymbols,
+  "\\p{scx=Bali}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Balinese}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Balinese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Balinese}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Balinese}"
 );
-assert(
-  /^\P{Script_Extensions=Bali}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bali}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bali}"
 );
-assert(
-  /^\P{scx=Balinese}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Balinese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Balinese}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Balinese}"
 );
-assert(
-  /^\P{scx=Bali}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bali}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bali}"
 );

--- a/output/Script_Extensions_-_Bamum.js
+++ b/output/Script_Extensions_-_Bamum.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x016800, 0x016A38]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Bamum}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bamum}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bamum}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bamum}"
 );
-assert(
-  /^\p{Script_Extensions=Bamu}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bamu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bamu}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bamu}"
 );
-assert(
-  /^\p{scx=Bamum}+$/u.test(matchSymbols),
-  "`\\p{scx=Bamum}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bamum}+$/u,
+  matchSymbols,
+  "\\p{scx=Bamum}"
 );
-assert(
-  /^\p{scx=Bamu}+$/u.test(matchSymbols),
-  "`\\p{scx=Bamu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bamu}+$/u,
+  matchSymbols,
+  "\\p{scx=Bamu}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x016A39, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Bamum}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bamum}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bamum}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bamum}"
 );
-assert(
-  /^\P{Script_Extensions=Bamu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bamu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bamu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bamu}"
 );
-assert(
-  /^\P{scx=Bamum}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bamum}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bamum}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bamum}"
 );
-assert(
-  /^\P{scx=Bamu}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bamu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bamu}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bamu}"
 );

--- a/output/Script_Extensions_-_Bassa_Vah.js
+++ b/output/Script_Extensions_-_Bassa_Vah.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x016AF0, 0x016AF5]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Bassa_Vah}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bassa_Vah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bassa_Vah}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bassa_Vah}"
 );
-assert(
-  /^\p{Script_Extensions=Bass}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bass}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bass}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bass}"
 );
-assert(
-  /^\p{scx=Bassa_Vah}+$/u.test(matchSymbols),
-  "`\\p{scx=Bassa_Vah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bassa_Vah}+$/u,
+  matchSymbols,
+  "\\p{scx=Bassa_Vah}"
 );
-assert(
-  /^\p{scx=Bass}+$/u.test(matchSymbols),
-  "`\\p{scx=Bass}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bass}+$/u,
+  matchSymbols,
+  "\\p{scx=Bass}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x016AF6, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Bassa_Vah}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bassa_Vah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bassa_Vah}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bassa_Vah}"
 );
-assert(
-  /^\P{Script_Extensions=Bass}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bass}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bass}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bass}"
 );
-assert(
-  /^\P{scx=Bassa_Vah}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bassa_Vah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bassa_Vah}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bassa_Vah}"
 );
-assert(
-  /^\P{scx=Bass}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bass}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bass}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bass}"
 );

--- a/output/Script_Extensions_-_Batak.js
+++ b/output/Script_Extensions_-_Batak.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x001BFC, 0x001BFF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Batak}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Batak}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Batak}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Batak}"
 );
-assert(
-  /^\p{Script_Extensions=Batk}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Batk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Batk}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Batk}"
 );
-assert(
-  /^\p{scx=Batak}+$/u.test(matchSymbols),
-  "`\\p{scx=Batak}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Batak}+$/u,
+  matchSymbols,
+  "\\p{scx=Batak}"
 );
-assert(
-  /^\p{scx=Batk}+$/u.test(matchSymbols),
-  "`\\p{scx=Batk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Batk}+$/u,
+  matchSymbols,
+  "\\p{scx=Batk}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Batak}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Batak}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Batak}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Batak}"
 );
-assert(
-  /^\P{Script_Extensions=Batk}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Batk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Batk}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Batk}"
 );
-assert(
-  /^\P{scx=Batak}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Batak}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Batak}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Batak}"
 );
-assert(
-  /^\P{scx=Batk}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Batk}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Batk}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Batk}"
 );

--- a/output/Script_Extensions_-_Bengali.js
+++ b/output/Script_Extensions_-_Bengali.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -36,21 +36,25 @@ const matchSymbols = buildString({
     [0x0009E6, 0x0009FB]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Bengali}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bengali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bengali}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bengali}"
 );
-assert(
-  /^\p{Script_Extensions=Beng}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Beng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Beng}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Beng}"
 );
-assert(
-  /^\p{scx=Bengali}+$/u.test(matchSymbols),
-  "`\\p{scx=Bengali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bengali}+$/u,
+  matchSymbols,
+  "\\p{scx=Bengali}"
 );
-assert(
-  /^\p{scx=Beng}+$/u.test(matchSymbols),
-  "`\\p{scx=Beng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Beng}+$/u,
+  matchSymbols,
+  "\\p{scx=Beng}"
 );
 
 const nonMatchSymbols = buildString({
@@ -79,19 +83,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Bengali}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bengali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bengali}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bengali}"
 );
-assert(
-  /^\P{Script_Extensions=Beng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Beng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Beng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Beng}"
 );
-assert(
-  /^\P{scx=Bengali}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bengali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bengali}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bengali}"
 );
-assert(
-  /^\P{scx=Beng}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Beng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Beng}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Beng}"
 );

--- a/output/Script_Extensions_-_Bhaiksuki.js
+++ b/output/Script_Extensions_-_Bhaiksuki.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x011C50, 0x011C6C]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Bhaiksuki}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bhaiksuki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bhaiksuki}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bhaiksuki}"
 );
-assert(
-  /^\p{Script_Extensions=Bhks}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bhks}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bhks}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bhks}"
 );
-assert(
-  /^\p{scx=Bhaiksuki}+$/u.test(matchSymbols),
-  "`\\p{scx=Bhaiksuki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bhaiksuki}+$/u,
+  matchSymbols,
+  "\\p{scx=Bhaiksuki}"
 );
-assert(
-  /^\p{scx=Bhks}+$/u.test(matchSymbols),
-  "`\\p{scx=Bhks}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bhks}+$/u,
+  matchSymbols,
+  "\\p{scx=Bhks}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x011C6D, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Bhaiksuki}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bhaiksuki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bhaiksuki}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bhaiksuki}"
 );
-assert(
-  /^\P{Script_Extensions=Bhks}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bhks}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bhks}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bhks}"
 );
-assert(
-  /^\P{scx=Bhaiksuki}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bhaiksuki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bhaiksuki}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bhaiksuki}"
 );
-assert(
-  /^\P{scx=Bhks}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bhks}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bhks}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bhks}"
 );

--- a/output/Script_Extensions_-_Bopomofo.js
+++ b/output/Script_Extensions_-_Bopomofo.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -31,21 +31,25 @@ const matchSymbols = buildString({
     [0x00FF61, 0x00FF65]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Bopomofo}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bopomofo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bopomofo}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bopomofo}"
 );
-assert(
-  /^\p{Script_Extensions=Bopo}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bopo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bopo}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bopo}"
 );
-assert(
-  /^\p{scx=Bopomofo}+$/u.test(matchSymbols),
-  "`\\p{scx=Bopomofo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bopomofo}+$/u,
+  matchSymbols,
+  "\\p{scx=Bopomofo}"
 );
-assert(
-  /^\p{scx=Bopo}+$/u.test(matchSymbols),
-  "`\\p{scx=Bopo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bopo}+$/u,
+  matchSymbols,
+  "\\p{scx=Bopo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -69,19 +73,23 @@ const nonMatchSymbols = buildString({
     [0x00FF66, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Bopomofo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bopomofo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bopomofo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bopomofo}"
 );
-assert(
-  /^\P{Script_Extensions=Bopo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bopo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bopo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bopo}"
 );
-assert(
-  /^\P{scx=Bopomofo}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bopomofo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bopomofo}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bopomofo}"
 );
-assert(
-  /^\P{scx=Bopo}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bopo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bopo}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bopo}"
 );

--- a/output/Script_Extensions_-_Brahmi.js
+++ b/output/Script_Extensions_-_Brahmi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x011052, 0x01106F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Brahmi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Brahmi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Brahmi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Brahmi}"
 );
-assert(
-  /^\p{Script_Extensions=Brah}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Brah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Brah}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Brah}"
 );
-assert(
-  /^\p{scx=Brahmi}+$/u.test(matchSymbols),
-  "`\\p{scx=Brahmi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Brahmi}+$/u,
+  matchSymbols,
+  "\\p{scx=Brahmi}"
 );
-assert(
-  /^\p{scx=Brah}+$/u.test(matchSymbols),
-  "`\\p{scx=Brah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Brah}+$/u,
+  matchSymbols,
+  "\\p{scx=Brah}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x011080, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Brahmi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Brahmi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Brahmi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Brahmi}"
 );
-assert(
-  /^\P{Script_Extensions=Brah}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Brah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Brah}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Brah}"
 );
-assert(
-  /^\P{scx=Brahmi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Brahmi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Brahmi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Brahmi}"
 );
-assert(
-  /^\P{scx=Brah}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Brah}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Brah}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Brah}"
 );

--- a/output/Script_Extensions_-_Braille.js
+++ b/output/Script_Extensions_-_Braille.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x002800, 0x0028FF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Braille}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Braille}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Braille}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Braille}"
 );
-assert(
-  /^\p{Script_Extensions=Brai}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Brai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Brai}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Brai}"
 );
-assert(
-  /^\p{scx=Braille}+$/u.test(matchSymbols),
-  "`\\p{scx=Braille}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Braille}+$/u,
+  matchSymbols,
+  "\\p{scx=Braille}"
 );
-assert(
-  /^\p{scx=Brai}+$/u.test(matchSymbols),
-  "`\\p{scx=Brai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Brai}+$/u,
+  matchSymbols,
+  "\\p{scx=Brai}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Braille}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Braille}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Braille}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Braille}"
 );
-assert(
-  /^\P{Script_Extensions=Brai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Brai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Brai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Brai}"
 );
-assert(
-  /^\P{scx=Braille}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Braille}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Braille}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Braille}"
 );
-assert(
-  /^\P{scx=Brai}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Brai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Brai}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Brai}"
 );

--- a/output/Script_Extensions_-_Buginese.js
+++ b/output/Script_Extensions_-_Buginese.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x001A1E, 0x001A1F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Buginese}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Buginese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Buginese}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Buginese}"
 );
-assert(
-  /^\p{Script_Extensions=Bugi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Bugi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Bugi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Bugi}"
 );
-assert(
-  /^\p{scx=Buginese}+$/u.test(matchSymbols),
-  "`\\p{scx=Buginese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Buginese}+$/u,
+  matchSymbols,
+  "\\p{scx=Buginese}"
 );
-assert(
-  /^\p{scx=Bugi}+$/u.test(matchSymbols),
-  "`\\p{scx=Bugi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Bugi}+$/u,
+  matchSymbols,
+  "\\p{scx=Bugi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Buginese}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Buginese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Buginese}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Buginese}"
 );
-assert(
-  /^\P{Script_Extensions=Bugi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Bugi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Bugi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Bugi}"
 );
-assert(
-  /^\P{scx=Buginese}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Buginese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Buginese}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Buginese}"
 );
-assert(
-  /^\P{scx=Bugi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Bugi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Bugi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Bugi}"
 );

--- a/output/Script_Extensions_-_Buhid.js
+++ b/output/Script_Extensions_-_Buhid.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x001740, 0x001753]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Buhid}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Buhid}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Buhid}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Buhid}"
 );
-assert(
-  /^\p{Script_Extensions=Buhd}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Buhd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Buhd}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Buhd}"
 );
-assert(
-  /^\p{scx=Buhid}+$/u.test(matchSymbols),
-  "`\\p{scx=Buhid}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Buhid}+$/u,
+  matchSymbols,
+  "\\p{scx=Buhid}"
 );
-assert(
-  /^\p{scx=Buhd}+$/u.test(matchSymbols),
-  "`\\p{scx=Buhd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Buhd}+$/u,
+  matchSymbols,
+  "\\p{scx=Buhd}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Buhid}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Buhid}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Buhid}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Buhid}"
 );
-assert(
-  /^\P{Script_Extensions=Buhd}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Buhd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Buhd}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Buhd}"
 );
-assert(
-  /^\P{scx=Buhid}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Buhid}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Buhid}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Buhid}"
 );
-assert(
-  /^\P{scx=Buhd}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Buhd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Buhd}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Buhd}"
 );

--- a/output/Script_Extensions_-_Canadian_Aboriginal.js
+++ b/output/Script_Extensions_-_Canadian_Aboriginal.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0018B0, 0x0018F5]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Canadian_Aboriginal}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Canadian_Aboriginal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Canadian_Aboriginal}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Canadian_Aboriginal}"
 );
-assert(
-  /^\p{Script_Extensions=Cans}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cans}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cans}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cans}"
 );
-assert(
-  /^\p{scx=Canadian_Aboriginal}+$/u.test(matchSymbols),
-  "`\\p{scx=Canadian_Aboriginal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Canadian_Aboriginal}+$/u,
+  matchSymbols,
+  "\\p{scx=Canadian_Aboriginal}"
 );
-assert(
-  /^\p{scx=Cans}+$/u.test(matchSymbols),
-  "`\\p{scx=Cans}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cans}+$/u,
+  matchSymbols,
+  "\\p{scx=Cans}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Canadian_Aboriginal}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Canadian_Aboriginal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Canadian_Aboriginal}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Canadian_Aboriginal}"
 );
-assert(
-  /^\P{Script_Extensions=Cans}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cans}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cans}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cans}"
 );
-assert(
-  /^\P{scx=Canadian_Aboriginal}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Canadian_Aboriginal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Canadian_Aboriginal}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Canadian_Aboriginal}"
 );
-assert(
-  /^\P{scx=Cans}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cans}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cans}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cans}"
 );

--- a/output/Script_Extensions_-_Carian.js
+++ b/output/Script_Extensions_-_Carian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x0102A0, 0x0102D0]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Carian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Carian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Carian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Carian}"
 );
-assert(
-  /^\p{Script_Extensions=Cari}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cari}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cari}"
 );
-assert(
-  /^\p{scx=Carian}+$/u.test(matchSymbols),
-  "`\\p{scx=Carian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Carian}+$/u,
+  matchSymbols,
+  "\\p{scx=Carian}"
 );
-assert(
-  /^\p{scx=Cari}+$/u.test(matchSymbols),
-  "`\\p{scx=Cari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cari}+$/u,
+  matchSymbols,
+  "\\p{scx=Cari}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x0102D1, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Carian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Carian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Carian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Carian}"
 );
-assert(
-  /^\P{Script_Extensions=Cari}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cari}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cari}"
 );
-assert(
-  /^\P{scx=Carian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Carian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Carian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Carian}"
 );
-assert(
-  /^\P{scx=Cari}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cari}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cari}"
 );

--- a/output/Script_Extensions_-_Caucasian_Albanian.js
+++ b/output/Script_Extensions_-_Caucasian_Albanian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010530, 0x010563]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Caucasian_Albanian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Caucasian_Albanian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Caucasian_Albanian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Caucasian_Albanian}"
 );
-assert(
-  /^\p{Script_Extensions=Aghb}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Aghb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Aghb}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Aghb}"
 );
-assert(
-  /^\p{scx=Caucasian_Albanian}+$/u.test(matchSymbols),
-  "`\\p{scx=Caucasian_Albanian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Caucasian_Albanian}+$/u,
+  matchSymbols,
+  "\\p{scx=Caucasian_Albanian}"
 );
-assert(
-  /^\p{scx=Aghb}+$/u.test(matchSymbols),
-  "`\\p{scx=Aghb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Aghb}+$/u,
+  matchSymbols,
+  "\\p{scx=Aghb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x010570, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Caucasian_Albanian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Caucasian_Albanian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Caucasian_Albanian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Caucasian_Albanian}"
 );
-assert(
-  /^\P{Script_Extensions=Aghb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Aghb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Aghb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Aghb}"
 );
-assert(
-  /^\P{scx=Caucasian_Albanian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Caucasian_Albanian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Caucasian_Albanian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Caucasian_Albanian}"
 );
-assert(
-  /^\P{scx=Aghb}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Aghb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Aghb}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Aghb}"
 );

--- a/output/Script_Extensions_-_Chakma.js
+++ b/output/Script_Extensions_-_Chakma.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x011136, 0x011143]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Chakma}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Chakma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Chakma}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Chakma}"
 );
-assert(
-  /^\p{Script_Extensions=Cakm}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cakm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cakm}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cakm}"
 );
-assert(
-  /^\p{scx=Chakma}+$/u.test(matchSymbols),
-  "`\\p{scx=Chakma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Chakma}+$/u,
+  matchSymbols,
+  "\\p{scx=Chakma}"
 );
-assert(
-  /^\p{scx=Cakm}+$/u.test(matchSymbols),
-  "`\\p{scx=Cakm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cakm}+$/u,
+  matchSymbols,
+  "\\p{scx=Cakm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x011144, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Chakma}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Chakma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Chakma}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Chakma}"
 );
-assert(
-  /^\P{Script_Extensions=Cakm}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cakm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cakm}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cakm}"
 );
-assert(
-  /^\P{scx=Chakma}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Chakma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Chakma}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Chakma}"
 );
-assert(
-  /^\P{scx=Cakm}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cakm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cakm}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cakm}"
 );

--- a/output/Script_Extensions_-_Cham.js
+++ b/output/Script_Extensions_-_Cham.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x00AA5C, 0x00AA5F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Cham}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cham}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cham}"
 );
-assert(
-  /^\p{Script_Extensions=Cham}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cham}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cham}"
 );
-assert(
-  /^\p{scx=Cham}+$/u.test(matchSymbols),
-  "`\\p{scx=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cham}+$/u,
+  matchSymbols,
+  "\\p{scx=Cham}"
 );
-assert(
-  /^\p{scx=Cham}+$/u.test(matchSymbols),
-  "`\\p{scx=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cham}+$/u,
+  matchSymbols,
+  "\\p{scx=Cham}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Cham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cham}"
 );
-assert(
-  /^\P{Script_Extensions=Cham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cham}"
 );
-assert(
-  /^\P{scx=Cham}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cham}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cham}"
 );
-assert(
-  /^\P{scx=Cham}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cham}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cham}"
 );

--- a/output/Script_Extensions_-_Cherokee.js
+++ b/output/Script_Extensions_-_Cherokee.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00AB70, 0x00ABBF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Cherokee}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cherokee}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cherokee}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cherokee}"
 );
-assert(
-  /^\p{Script_Extensions=Cher}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cher}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cher}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cher}"
 );
-assert(
-  /^\p{scx=Cherokee}+$/u.test(matchSymbols),
-  "`\\p{scx=Cherokee}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cherokee}+$/u,
+  matchSymbols,
+  "\\p{scx=Cherokee}"
 );
-assert(
-  /^\p{scx=Cher}+$/u.test(matchSymbols),
-  "`\\p{scx=Cher}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cher}+$/u,
+  matchSymbols,
+  "\\p{scx=Cher}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Cherokee}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cherokee}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cherokee}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cherokee}"
 );
-assert(
-  /^\P{Script_Extensions=Cher}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cher}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cher}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cher}"
 );
-assert(
-  /^\P{scx=Cherokee}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cherokee}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cherokee}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cherokee}"
 );
-assert(
-  /^\P{scx=Cher}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cher}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cher}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cher}"
 );

--- a/output/Script_Extensions_-_Common.js
+++ b/output/Script_Extensions_-_Common.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -159,21 +159,25 @@ const matchSymbols = buildString({
     [0x0E0020, 0x0E007F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Common}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Common}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Common}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Common}"
 );
-assert(
-  /^\p{Script_Extensions=Zyyy}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Zyyy}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Zyyy}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Zyyy}"
 );
-assert(
-  /^\p{scx=Common}+$/u.test(matchSymbols),
-  "`\\p{scx=Common}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Common}+$/u,
+  matchSymbols,
+  "\\p{scx=Common}"
 );
-assert(
-  /^\p{scx=Zyyy}+$/u.test(matchSymbols),
-  "`\\p{scx=Zyyy}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Zyyy}+$/u,
+  matchSymbols,
+  "\\p{scx=Zyyy}"
 );
 
 const nonMatchSymbols = buildString({
@@ -324,19 +328,23 @@ const nonMatchSymbols = buildString({
     [0x0E0080, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Common}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Common}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Common}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Common}"
 );
-assert(
-  /^\P{Script_Extensions=Zyyy}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Zyyy}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Zyyy}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Zyyy}"
 );
-assert(
-  /^\P{scx=Common}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Common}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Common}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Common}"
 );
-assert(
-  /^\P{scx=Zyyy}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Zyyy}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Zyyy}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Zyyy}"
 );

--- a/output/Script_Extensions_-_Coptic.js
+++ b/output/Script_Extensions_-_Coptic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,29 +22,35 @@ const matchSymbols = buildString({
     [0x0102E0, 0x0102FB]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Coptic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Coptic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Coptic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Coptic}"
 );
-assert(
-  /^\p{Script_Extensions=Copt}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Copt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Copt}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Copt}"
 );
-assert(
-  /^\p{Script_Extensions=Qaac}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Qaac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Qaac}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Qaac}"
 );
-assert(
-  /^\p{scx=Coptic}+$/u.test(matchSymbols),
-  "`\\p{scx=Coptic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Coptic}+$/u,
+  matchSymbols,
+  "\\p{scx=Coptic}"
 );
-assert(
-  /^\p{scx=Copt}+$/u.test(matchSymbols),
-  "`\\p{scx=Copt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Copt}+$/u,
+  matchSymbols,
+  "\\p{scx=Copt}"
 );
-assert(
-  /^\p{scx=Qaac}+$/u.test(matchSymbols),
-  "`\\p{scx=Qaac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Qaac}+$/u,
+  matchSymbols,
+  "\\p{scx=Qaac}"
 );
 
 const nonMatchSymbols = buildString({
@@ -59,27 +65,33 @@ const nonMatchSymbols = buildString({
     [0x0102FC, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Coptic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Coptic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Coptic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Coptic}"
 );
-assert(
-  /^\P{Script_Extensions=Copt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Copt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Copt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Copt}"
 );
-assert(
-  /^\P{Script_Extensions=Qaac}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Qaac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Qaac}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Qaac}"
 );
-assert(
-  /^\P{scx=Coptic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Coptic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Coptic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Coptic}"
 );
-assert(
-  /^\P{scx=Copt}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Copt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Copt}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Copt}"
 );
-assert(
-  /^\P{scx=Qaac}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Qaac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Qaac}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Qaac}"
 );

--- a/output/Script_Extensions_-_Cuneiform.js
+++ b/output/Script_Extensions_-_Cuneiform.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x012480, 0x012543]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Cuneiform}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cuneiform}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cuneiform}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cuneiform}"
 );
-assert(
-  /^\p{Script_Extensions=Xsux}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Xsux}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Xsux}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Xsux}"
 );
-assert(
-  /^\p{scx=Cuneiform}+$/u.test(matchSymbols),
-  "`\\p{scx=Cuneiform}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cuneiform}+$/u,
+  matchSymbols,
+  "\\p{scx=Cuneiform}"
 );
-assert(
-  /^\p{scx=Xsux}+$/u.test(matchSymbols),
-  "`\\p{scx=Xsux}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Xsux}+$/u,
+  matchSymbols,
+  "\\p{scx=Xsux}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x012544, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Cuneiform}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cuneiform}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cuneiform}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cuneiform}"
 );
-assert(
-  /^\P{Script_Extensions=Xsux}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Xsux}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Xsux}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Xsux}"
 );
-assert(
-  /^\P{scx=Cuneiform}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cuneiform}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cuneiform}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cuneiform}"
 );
-assert(
-  /^\P{scx=Xsux}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Xsux}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Xsux}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Xsux}"
 );

--- a/output/Script_Extensions_-_Cypriot.js
+++ b/output/Script_Extensions_-_Cypriot.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -28,21 +28,25 @@ const matchSymbols = buildString({
     [0x010837, 0x010838]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Cypriot}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cypriot}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cypriot}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cypriot}"
 );
-assert(
-  /^\p{Script_Extensions=Cprt}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cprt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cprt}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cprt}"
 );
-assert(
-  /^\p{scx=Cypriot}+$/u.test(matchSymbols),
-  "`\\p{scx=Cypriot}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cypriot}+$/u,
+  matchSymbols,
+  "\\p{scx=Cypriot}"
 );
-assert(
-  /^\p{scx=Cprt}+$/u.test(matchSymbols),
-  "`\\p{scx=Cprt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cprt}+$/u,
+  matchSymbols,
+  "\\p{scx=Cprt}"
 );
 
 const nonMatchSymbols = buildString({
@@ -63,19 +67,23 @@ const nonMatchSymbols = buildString({
     [0x010840, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Cypriot}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cypriot}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cypriot}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cypriot}"
 );
-assert(
-  /^\P{Script_Extensions=Cprt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cprt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cprt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cprt}"
 );
-assert(
-  /^\P{scx=Cypriot}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cypriot}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cypriot}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cypriot}"
 );
-assert(
-  /^\P{scx=Cprt}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cprt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cprt}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cprt}"
 );

--- a/output/Script_Extensions_-_Cyrillic.js
+++ b/output/Script_Extensions_-_Cyrillic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -27,21 +27,25 @@ const matchSymbols = buildString({
     [0x00FE2E, 0x00FE2F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Cyrillic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cyrillic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cyrillic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cyrillic}"
 );
-assert(
-  /^\p{Script_Extensions=Cyrl}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Cyrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Cyrl}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Cyrl}"
 );
-assert(
-  /^\p{scx=Cyrillic}+$/u.test(matchSymbols),
-  "`\\p{scx=Cyrillic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cyrillic}+$/u,
+  matchSymbols,
+  "\\p{scx=Cyrillic}"
 );
-assert(
-  /^\p{scx=Cyrl}+$/u.test(matchSymbols),
-  "`\\p{scx=Cyrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Cyrl}+$/u,
+  matchSymbols,
+  "\\p{scx=Cyrl}"
 );
 
 const nonMatchSymbols = buildString({
@@ -60,19 +64,23 @@ const nonMatchSymbols = buildString({
     [0x00FE30, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Cyrillic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cyrillic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cyrillic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cyrillic}"
 );
-assert(
-  /^\P{Script_Extensions=Cyrl}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Cyrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Cyrl}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Cyrl}"
 );
-assert(
-  /^\P{scx=Cyrillic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cyrillic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cyrillic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cyrillic}"
 );
-assert(
-  /^\P{scx=Cyrl}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Cyrl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Cyrl}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Cyrl}"
 );

--- a/output/Script_Extensions_-_Deseret.js
+++ b/output/Script_Extensions_-_Deseret.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010400, 0x01044F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Deseret}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Deseret}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Deseret}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Deseret}"
 );
-assert(
-  /^\p{Script_Extensions=Dsrt}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Dsrt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Dsrt}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Dsrt}"
 );
-assert(
-  /^\p{scx=Deseret}+$/u.test(matchSymbols),
-  "`\\p{scx=Deseret}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Deseret}+$/u,
+  matchSymbols,
+  "\\p{scx=Deseret}"
 );
-assert(
-  /^\p{scx=Dsrt}+$/u.test(matchSymbols),
-  "`\\p{scx=Dsrt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Dsrt}+$/u,
+  matchSymbols,
+  "\\p{scx=Dsrt}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010450, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Deseret}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Deseret}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Deseret}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Deseret}"
 );
-assert(
-  /^\P{Script_Extensions=Dsrt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Dsrt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Dsrt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Dsrt}"
 );
-assert(
-  /^\P{scx=Deseret}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Deseret}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Deseret}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Deseret}"
 );
-assert(
-  /^\P{scx=Dsrt}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Dsrt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Dsrt}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Dsrt}"
 );

--- a/output/Script_Extensions_-_Devanagari.js
+++ b/output/Script_Extensions_-_Devanagari.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,21 +25,25 @@ const matchSymbols = buildString({
     [0x00A8E0, 0x00A8FD]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Devanagari}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Devanagari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Devanagari}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Devanagari}"
 );
-assert(
-  /^\p{Script_Extensions=Deva}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Deva}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Deva}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Deva}"
 );
-assert(
-  /^\p{scx=Devanagari}+$/u.test(matchSymbols),
-  "`\\p{scx=Devanagari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Devanagari}+$/u,
+  matchSymbols,
+  "\\p{scx=Devanagari}"
 );
-assert(
-  /^\p{scx=Deva}+$/u.test(matchSymbols),
-  "`\\p{scx=Deva}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Deva}+$/u,
+  matchSymbols,
+  "\\p{scx=Deva}"
 );
 
 const nonMatchSymbols = buildString({
@@ -57,19 +61,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Devanagari}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Devanagari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Devanagari}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Devanagari}"
 );
-assert(
-  /^\P{Script_Extensions=Deva}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Deva}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Deva}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Deva}"
 );
-assert(
-  /^\P{scx=Devanagari}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Devanagari}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Devanagari}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Devanagari}"
 );
-assert(
-  /^\P{scx=Deva}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Deva}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Deva}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Deva}"
 );

--- a/output/Script_Extensions_-_Duployan.js
+++ b/output/Script_Extensions_-_Duployan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x01BC9C, 0x01BCA3]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Duployan}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Duployan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Duployan}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Duployan}"
 );
-assert(
-  /^\p{Script_Extensions=Dupl}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Dupl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Dupl}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Dupl}"
 );
-assert(
-  /^\p{scx=Duployan}+$/u.test(matchSymbols),
-  "`\\p{scx=Duployan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Duployan}+$/u,
+  matchSymbols,
+  "\\p{scx=Duployan}"
 );
-assert(
-  /^\p{scx=Dupl}+$/u.test(matchSymbols),
-  "`\\p{scx=Dupl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Dupl}+$/u,
+  matchSymbols,
+  "\\p{scx=Dupl}"
 );
 
 const nonMatchSymbols = buildString({
@@ -53,19 +57,23 @@ const nonMatchSymbols = buildString({
     [0x01BCA4, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Duployan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Duployan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Duployan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Duployan}"
 );
-assert(
-  /^\P{Script_Extensions=Dupl}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Dupl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Dupl}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Dupl}"
 );
-assert(
-  /^\P{scx=Duployan}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Duployan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Duployan}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Duployan}"
 );
-assert(
-  /^\P{scx=Dupl}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Dupl}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Dupl}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Dupl}"
 );

--- a/output/Script_Extensions_-_Egyptian_Hieroglyphs.js
+++ b/output/Script_Extensions_-_Egyptian_Hieroglyphs.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x013000, 0x01342E]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Egyptian_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Egyptian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Egyptian_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Egyptian_Hieroglyphs}"
 );
-assert(
-  /^\p{Script_Extensions=Egyp}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Egyp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Egyp}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Egyp}"
 );
-assert(
-  /^\p{scx=Egyptian_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{scx=Egyptian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Egyptian_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{scx=Egyptian_Hieroglyphs}"
 );
-assert(
-  /^\p{scx=Egyp}+$/u.test(matchSymbols),
-  "`\\p{scx=Egyp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Egyp}+$/u,
+  matchSymbols,
+  "\\p{scx=Egyp}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x01342F, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Egyptian_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Egyptian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Egyptian_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Egyptian_Hieroglyphs}"
 );
-assert(
-  /^\P{Script_Extensions=Egyp}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Egyp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Egyp}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Egyp}"
 );
-assert(
-  /^\P{scx=Egyptian_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Egyptian_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Egyptian_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Egyptian_Hieroglyphs}"
 );
-assert(
-  /^\P{scx=Egyp}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Egyp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Egyp}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Egyp}"
 );

--- a/output/Script_Extensions_-_Elbasan.js
+++ b/output/Script_Extensions_-_Elbasan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010500, 0x010527]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Elbasan}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Elbasan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Elbasan}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Elbasan}"
 );
-assert(
-  /^\p{Script_Extensions=Elba}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Elba}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Elba}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Elba}"
 );
-assert(
-  /^\p{scx=Elbasan}+$/u.test(matchSymbols),
-  "`\\p{scx=Elbasan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Elbasan}+$/u,
+  matchSymbols,
+  "\\p{scx=Elbasan}"
 );
-assert(
-  /^\p{scx=Elba}+$/u.test(matchSymbols),
-  "`\\p{scx=Elba}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Elba}+$/u,
+  matchSymbols,
+  "\\p{scx=Elba}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010528, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Elbasan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Elbasan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Elbasan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Elbasan}"
 );
-assert(
-  /^\P{Script_Extensions=Elba}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Elba}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Elba}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Elba}"
 );
-assert(
-  /^\P{scx=Elbasan}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Elbasan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Elbasan}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Elbasan}"
 );
-assert(
-  /^\P{scx=Elba}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Elba}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Elba}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Elba}"
 );

--- a/output/Script_Extensions_-_Ethiopic.js
+++ b/output/Script_Extensions_-_Ethiopic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -51,21 +51,25 @@ const matchSymbols = buildString({
     [0x00AB28, 0x00AB2E]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Ethiopic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ethiopic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ethiopic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ethiopic}"
 );
-assert(
-  /^\p{Script_Extensions=Ethi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ethi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ethi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ethi}"
 );
-assert(
-  /^\p{scx=Ethiopic}+$/u.test(matchSymbols),
-  "`\\p{scx=Ethiopic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ethiopic}+$/u,
+  matchSymbols,
+  "\\p{scx=Ethiopic}"
 );
-assert(
-  /^\p{scx=Ethi}+$/u.test(matchSymbols),
-  "`\\p{scx=Ethi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ethi}+$/u,
+  matchSymbols,
+  "\\p{scx=Ethi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -109,19 +113,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Ethiopic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ethiopic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ethiopic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ethiopic}"
 );
-assert(
-  /^\P{Script_Extensions=Ethi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ethi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ethi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ethi}"
 );
-assert(
-  /^\P{scx=Ethiopic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ethiopic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ethiopic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ethiopic}"
 );
-assert(
-  /^\P{scx=Ethi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ethi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ethi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ethi}"
 );

--- a/output/Script_Extensions_-_Georgian.js
+++ b/output/Script_Extensions_-_Georgian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -27,21 +27,25 @@ const matchSymbols = buildString({
     [0x002D00, 0x002D25]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Georgian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Georgian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Georgian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Georgian}"
 );
-assert(
-  /^\p{Script_Extensions=Geor}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Geor}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Geor}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Geor}"
 );
-assert(
-  /^\p{scx=Georgian}+$/u.test(matchSymbols),
-  "`\\p{scx=Georgian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Georgian}+$/u,
+  matchSymbols,
+  "\\p{scx=Georgian}"
 );
-assert(
-  /^\p{scx=Geor}+$/u.test(matchSymbols),
-  "`\\p{scx=Geor}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Geor}+$/u,
+  matchSymbols,
+  "\\p{scx=Geor}"
 );
 
 const nonMatchSymbols = buildString({
@@ -61,19 +65,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Georgian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Georgian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Georgian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Georgian}"
 );
-assert(
-  /^\P{Script_Extensions=Geor}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Geor}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Geor}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Geor}"
 );
-assert(
-  /^\P{scx=Georgian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Georgian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Georgian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Georgian}"
 );
-assert(
-  /^\P{scx=Geor}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Geor}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Geor}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Geor}"
 );

--- a/output/Script_Extensions_-_Glagolitic.js
+++ b/output/Script_Extensions_-_Glagolitic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -30,21 +30,25 @@ const matchSymbols = buildString({
     [0x01E026, 0x01E02A]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Glagolitic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Glagolitic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Glagolitic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Glagolitic}"
 );
-assert(
-  /^\p{Script_Extensions=Glag}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Glag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Glag}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Glag}"
 );
-assert(
-  /^\p{scx=Glagolitic}+$/u.test(matchSymbols),
-  "`\\p{scx=Glagolitic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Glagolitic}+$/u,
+  matchSymbols,
+  "\\p{scx=Glagolitic}"
 );
-assert(
-  /^\p{scx=Glag}+$/u.test(matchSymbols),
-  "`\\p{scx=Glag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Glag}+$/u,
+  matchSymbols,
+  "\\p{scx=Glag}"
 );
 
 const nonMatchSymbols = buildString({
@@ -67,19 +71,23 @@ const nonMatchSymbols = buildString({
     [0x01E02B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Glagolitic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Glagolitic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Glagolitic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Glagolitic}"
 );
-assert(
-  /^\P{Script_Extensions=Glag}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Glag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Glag}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Glag}"
 );
-assert(
-  /^\P{scx=Glagolitic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Glagolitic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Glagolitic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Glagolitic}"
 );
-assert(
-  /^\P{scx=Glag}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Glag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Glag}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Glag}"
 );

--- a/output/Script_Extensions_-_Gothic.js
+++ b/output/Script_Extensions_-_Gothic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010330, 0x01034A]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Gothic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Gothic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Gothic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Gothic}"
 );
-assert(
-  /^\p{Script_Extensions=Goth}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Goth}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Goth}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Goth}"
 );
-assert(
-  /^\p{scx=Gothic}+$/u.test(matchSymbols),
-  "`\\p{scx=Gothic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Gothic}+$/u,
+  matchSymbols,
+  "\\p{scx=Gothic}"
 );
-assert(
-  /^\p{scx=Goth}+$/u.test(matchSymbols),
-  "`\\p{scx=Goth}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Goth}+$/u,
+  matchSymbols,
+  "\\p{scx=Goth}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x01034B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Gothic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Gothic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Gothic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Gothic}"
 );
-assert(
-  /^\P{Script_Extensions=Goth}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Goth}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Goth}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Goth}"
 );
-assert(
-  /^\P{scx=Gothic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Gothic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Gothic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Gothic}"
 );
-assert(
-  /^\P{scx=Goth}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Goth}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Goth}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Goth}"
 );

--- a/output/Script_Extensions_-_Grantha.js
+++ b/output/Script_Extensions_-_Grantha.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -44,21 +44,25 @@ const matchSymbols = buildString({
     [0x011370, 0x011374]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Grantha}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Grantha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Grantha}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Grantha}"
 );
-assert(
-  /^\p{Script_Extensions=Gran}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Gran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Gran}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Gran}"
 );
-assert(
-  /^\p{scx=Grantha}+$/u.test(matchSymbols),
-  "`\\p{scx=Grantha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Grantha}+$/u,
+  matchSymbols,
+  "\\p{scx=Grantha}"
 );
-assert(
-  /^\p{scx=Gran}+$/u.test(matchSymbols),
-  "`\\p{scx=Gran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Gran}+$/u,
+  matchSymbols,
+  "\\p{scx=Gran}"
 );
 
 const nonMatchSymbols = buildString({
@@ -95,19 +99,23 @@ const nonMatchSymbols = buildString({
     [0x011375, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Grantha}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Grantha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Grantha}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Grantha}"
 );
-assert(
-  /^\P{Script_Extensions=Gran}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Gran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Gran}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Gran}"
 );
-assert(
-  /^\P{scx=Grantha}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Grantha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Grantha}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Grantha}"
 );
-assert(
-  /^\P{scx=Gran}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Gran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Gran}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Gran}"
 );

--- a/output/Script_Extensions_-_Greek.js
+++ b/output/Script_Extensions_-_Greek.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -57,21 +57,25 @@ const matchSymbols = buildString({
     [0x01D200, 0x01D245]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Greek}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Greek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Greek}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Greek}"
 );
-assert(
-  /^\p{Script_Extensions=Grek}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Grek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Grek}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Grek}"
 );
-assert(
-  /^\p{scx=Greek}+$/u.test(matchSymbols),
-  "`\\p{scx=Greek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Greek}+$/u,
+  matchSymbols,
+  "\\p{scx=Greek}"
 );
-assert(
-  /^\p{scx=Grek}+$/u.test(matchSymbols),
-  "`\\p{scx=Grek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Grek}+$/u,
+  matchSymbols,
+  "\\p{scx=Grek}"
 );
 
 const nonMatchSymbols = buildString({
@@ -121,19 +125,23 @@ const nonMatchSymbols = buildString({
     [0x01D246, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Greek}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Greek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Greek}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Greek}"
 );
-assert(
-  /^\P{Script_Extensions=Grek}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Grek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Grek}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Grek}"
 );
-assert(
-  /^\P{scx=Greek}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Greek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Greek}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Greek}"
 );
-assert(
-  /^\P{scx=Grek}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Grek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Grek}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Grek}"
 );

--- a/output/Script_Extensions_-_Gujarati.js
+++ b/output/Script_Extensions_-_Gujarati.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -36,21 +36,25 @@ const matchSymbols = buildString({
     [0x00A830, 0x00A839]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Gujarati}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Gujarati}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Gujarati}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Gujarati}"
 );
-assert(
-  /^\p{Script_Extensions=Gujr}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Gujr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Gujr}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Gujr}"
 );
-assert(
-  /^\p{scx=Gujarati}+$/u.test(matchSymbols),
-  "`\\p{scx=Gujarati}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Gujarati}+$/u,
+  matchSymbols,
+  "\\p{scx=Gujarati}"
 );
-assert(
-  /^\p{scx=Gujr}+$/u.test(matchSymbols),
-  "`\\p{scx=Gujr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Gujr}+$/u,
+  matchSymbols,
+  "\\p{scx=Gujr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -79,19 +83,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Gujarati}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Gujarati}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Gujarati}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Gujarati}"
 );
-assert(
-  /^\P{Script_Extensions=Gujr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Gujr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Gujr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Gujr}"
 );
-assert(
-  /^\P{scx=Gujarati}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Gujarati}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Gujarati}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Gujarati}"
 );
-assert(
-  /^\P{scx=Gujr}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Gujr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Gujr}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Gujr}"
 );

--- a/output/Script_Extensions_-_Gurmukhi.js
+++ b/output/Script_Extensions_-_Gurmukhi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -38,21 +38,25 @@ const matchSymbols = buildString({
     [0x00A830, 0x00A839]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Gurmukhi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Gurmukhi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Gurmukhi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Gurmukhi}"
 );
-assert(
-  /^\p{Script_Extensions=Guru}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Guru}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Guru}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Guru}"
 );
-assert(
-  /^\p{scx=Gurmukhi}+$/u.test(matchSymbols),
-  "`\\p{scx=Gurmukhi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Gurmukhi}+$/u,
+  matchSymbols,
+  "\\p{scx=Gurmukhi}"
 );
-assert(
-  /^\p{scx=Guru}+$/u.test(matchSymbols),
-  "`\\p{scx=Guru}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Guru}+$/u,
+  matchSymbols,
+  "\\p{scx=Guru}"
 );
 
 const nonMatchSymbols = buildString({
@@ -83,19 +87,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Gurmukhi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Gurmukhi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Gurmukhi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Gurmukhi}"
 );
-assert(
-  /^\P{Script_Extensions=Guru}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Guru}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Guru}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Guru}"
 );
-assert(
-  /^\P{scx=Gurmukhi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Gurmukhi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Gurmukhi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Gurmukhi}"
 );
-assert(
-  /^\P{scx=Guru}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Guru}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Guru}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Guru}"
 );

--- a/output/Script_Extensions_-_Han.js
+++ b/output/Script_Extensions_-_Han.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -50,21 +50,25 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Han}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Han}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Han}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Han}"
 );
-assert(
-  /^\p{Script_Extensions=Hani}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hani}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hani}"
 );
-assert(
-  /^\p{scx=Han}+$/u.test(matchSymbols),
-  "`\\p{scx=Han}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Han}+$/u,
+  matchSymbols,
+  "\\p{scx=Han}"
 );
-assert(
-  /^\p{scx=Hani}+$/u.test(matchSymbols),
-  "`\\p{scx=Hani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hani}+$/u,
+  matchSymbols,
+  "\\p{scx=Hani}"
 );
 
 const nonMatchSymbols = buildString({
@@ -107,19 +111,23 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Han}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Han}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Han}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Han}"
 );
-assert(
-  /^\P{Script_Extensions=Hani}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hani}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hani}"
 );
-assert(
-  /^\P{scx=Han}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Han}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Han}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Han}"
 );
-assert(
-  /^\P{scx=Hani}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hani}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hani}"
 );

--- a/output/Script_Extensions_-_Hangul.js
+++ b/output/Script_Extensions_-_Hangul.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -40,21 +40,25 @@ const matchSymbols = buildString({
     [0x00FFDA, 0x00FFDC]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Hangul}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hangul}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hangul}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hangul}"
 );
-assert(
-  /^\p{Script_Extensions=Hang}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hang}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hang}"
 );
-assert(
-  /^\p{scx=Hangul}+$/u.test(matchSymbols),
-  "`\\p{scx=Hangul}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hangul}+$/u,
+  matchSymbols,
+  "\\p{scx=Hangul}"
 );
-assert(
-  /^\p{scx=Hang}+$/u.test(matchSymbols),
-  "`\\p{scx=Hang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hang}+$/u,
+  matchSymbols,
+  "\\p{scx=Hang}"
 );
 
 const nonMatchSymbols = buildString({
@@ -87,19 +91,23 @@ const nonMatchSymbols = buildString({
     [0x00FFDD, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Hangul}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hangul}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hangul}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hangul}"
 );
-assert(
-  /^\P{Script_Extensions=Hang}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hang}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hang}"
 );
-assert(
-  /^\P{scx=Hangul}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hangul}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hangul}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hangul}"
 );
-assert(
-  /^\P{scx=Hang}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hang}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hang}"
 );

--- a/output/Script_Extensions_-_Hanunoo.js
+++ b/output/Script_Extensions_-_Hanunoo.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x001720, 0x001736]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Hanunoo}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hanunoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hanunoo}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hanunoo}"
 );
-assert(
-  /^\p{Script_Extensions=Hano}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hano}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hano}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hano}"
 );
-assert(
-  /^\p{scx=Hanunoo}+$/u.test(matchSymbols),
-  "`\\p{scx=Hanunoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hanunoo}+$/u,
+  matchSymbols,
+  "\\p{scx=Hanunoo}"
 );
-assert(
-  /^\p{scx=Hano}+$/u.test(matchSymbols),
-  "`\\p{scx=Hano}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hano}+$/u,
+  matchSymbols,
+  "\\p{scx=Hano}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Hanunoo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hanunoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hanunoo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hanunoo}"
 );
-assert(
-  /^\P{Script_Extensions=Hano}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hano}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hano}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hano}"
 );
-assert(
-  /^\P{scx=Hanunoo}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hanunoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hanunoo}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hanunoo}"
 );
-assert(
-  /^\P{scx=Hano}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hano}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hano}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hano}"
 );

--- a/output/Script_Extensions_-_Hatran.js
+++ b/output/Script_Extensions_-_Hatran.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x0108FB, 0x0108FF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Hatran}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hatran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hatran}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hatran}"
 );
-assert(
-  /^\p{Script_Extensions=Hatr}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hatr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hatr}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hatr}"
 );
-assert(
-  /^\p{scx=Hatran}+$/u.test(matchSymbols),
-  "`\\p{scx=Hatran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hatran}+$/u,
+  matchSymbols,
+  "\\p{scx=Hatran}"
 );
-assert(
-  /^\p{scx=Hatr}+$/u.test(matchSymbols),
-  "`\\p{scx=Hatr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hatr}+$/u,
+  matchSymbols,
+  "\\p{scx=Hatr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x010900, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Hatran}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hatran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hatran}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hatran}"
 );
-assert(
-  /^\P{Script_Extensions=Hatr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hatr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hatr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hatr}"
 );
-assert(
-  /^\P{scx=Hatran}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hatran}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hatran}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hatran}"
 );
-assert(
-  /^\P{scx=Hatr}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hatr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hatr}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hatr}"
 );

--- a/output/Script_Extensions_-_Hebrew.js
+++ b/output/Script_Extensions_-_Hebrew.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -28,21 +28,25 @@ const matchSymbols = buildString({
     [0x00FB46, 0x00FB4F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Hebrew}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hebrew}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hebrew}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hebrew}"
 );
-assert(
-  /^\p{Script_Extensions=Hebr}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hebr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hebr}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hebr}"
 );
-assert(
-  /^\p{scx=Hebrew}+$/u.test(matchSymbols),
-  "`\\p{scx=Hebrew}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hebrew}+$/u,
+  matchSymbols,
+  "\\p{scx=Hebrew}"
 );
-assert(
-  /^\p{scx=Hebr}+$/u.test(matchSymbols),
-  "`\\p{scx=Hebr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hebr}+$/u,
+  matchSymbols,
+  "\\p{scx=Hebr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -63,19 +67,23 @@ const nonMatchSymbols = buildString({
     [0x00FB50, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Hebrew}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hebrew}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hebrew}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hebrew}"
 );
-assert(
-  /^\P{Script_Extensions=Hebr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hebr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hebr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hebr}"
 );
-assert(
-  /^\P{scx=Hebrew}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hebrew}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hebrew}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hebrew}"
 );
-assert(
-  /^\P{scx=Hebr}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hebr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hebr}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hebr}"
 );

--- a/output/Script_Extensions_-_Hiragana.js
+++ b/output/Script_Extensions_-_Hiragana.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -34,21 +34,25 @@ const matchSymbols = buildString({
     [0x00FF9E, 0x00FF9F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Hiragana}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hiragana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hiragana}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hiragana}"
 );
-assert(
-  /^\p{Script_Extensions=Hira}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hira}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hira}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hira}"
 );
-assert(
-  /^\p{scx=Hiragana}+$/u.test(matchSymbols),
-  "`\\p{scx=Hiragana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hiragana}+$/u,
+  matchSymbols,
+  "\\p{scx=Hiragana}"
 );
-assert(
-  /^\p{scx=Hira}+$/u.test(matchSymbols),
-  "`\\p{scx=Hira}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hira}+$/u,
+  matchSymbols,
+  "\\p{scx=Hira}"
 );
 
 const nonMatchSymbols = buildString({
@@ -75,19 +79,23 @@ const nonMatchSymbols = buildString({
     [0x01F201, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Hiragana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hiragana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hiragana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hiragana}"
 );
-assert(
-  /^\P{Script_Extensions=Hira}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hira}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hira}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hira}"
 );
-assert(
-  /^\P{scx=Hiragana}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hiragana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hiragana}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hiragana}"
 );
-assert(
-  /^\P{scx=Hira}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hira}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hira}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hira}"
 );

--- a/output/Script_Extensions_-_Imperial_Aramaic.js
+++ b/output/Script_Extensions_-_Imperial_Aramaic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x010857, 0x01085F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Imperial_Aramaic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Imperial_Aramaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Imperial_Aramaic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Imperial_Aramaic}"
 );
-assert(
-  /^\p{Script_Extensions=Armi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Armi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Armi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Armi}"
 );
-assert(
-  /^\p{scx=Imperial_Aramaic}+$/u.test(matchSymbols),
-  "`\\p{scx=Imperial_Aramaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Imperial_Aramaic}+$/u,
+  matchSymbols,
+  "\\p{scx=Imperial_Aramaic}"
 );
-assert(
-  /^\p{scx=Armi}+$/u.test(matchSymbols),
-  "`\\p{scx=Armi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Armi}+$/u,
+  matchSymbols,
+  "\\p{scx=Armi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x010860, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Imperial_Aramaic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Imperial_Aramaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Imperial_Aramaic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Imperial_Aramaic}"
 );
-assert(
-  /^\P{Script_Extensions=Armi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Armi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Armi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Armi}"
 );
-assert(
-  /^\P{scx=Imperial_Aramaic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Imperial_Aramaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Imperial_Aramaic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Imperial_Aramaic}"
 );
-assert(
-  /^\P{scx=Armi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Armi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Armi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Armi}"
 );

--- a/output/Script_Extensions_-_Inherited.js
+++ b/output/Script_Extensions_-_Inherited.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -46,29 +46,35 @@ const matchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Inherited}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Inherited}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Inherited}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Inherited}"
 );
-assert(
-  /^\p{Script_Extensions=Zinh}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Zinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Zinh}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Zinh}"
 );
-assert(
-  /^\p{Script_Extensions=Qaai}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Qaai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Qaai}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Qaai}"
 );
-assert(
-  /^\p{scx=Inherited}+$/u.test(matchSymbols),
-  "`\\p{scx=Inherited}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Inherited}+$/u,
+  matchSymbols,
+  "\\p{scx=Inherited}"
 );
-assert(
-  /^\p{scx=Zinh}+$/u.test(matchSymbols),
-  "`\\p{scx=Zinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Zinh}+$/u,
+  matchSymbols,
+  "\\p{scx=Zinh}"
 );
-assert(
-  /^\p{scx=Qaai}+$/u.test(matchSymbols),
-  "`\\p{scx=Qaai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Qaai}+$/u,
+  matchSymbols,
+  "\\p{scx=Qaai}"
 );
 
 const nonMatchSymbols = buildString({
@@ -107,27 +113,33 @@ const nonMatchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Inherited}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Inherited}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Inherited}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Inherited}"
 );
-assert(
-  /^\P{Script_Extensions=Zinh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Zinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Zinh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Zinh}"
 );
-assert(
-  /^\P{Script_Extensions=Qaai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Qaai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Qaai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Qaai}"
 );
-assert(
-  /^\P{scx=Inherited}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Inherited}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Inherited}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Inherited}"
 );
-assert(
-  /^\P{scx=Zinh}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Zinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Zinh}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Zinh}"
 );
-assert(
-  /^\P{scx=Qaai}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Qaai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Qaai}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Qaai}"
 );

--- a/output/Script_Extensions_-_Inscriptional_Pahlavi.js
+++ b/output/Script_Extensions_-_Inscriptional_Pahlavi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x010B78, 0x010B7F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Inscriptional_Pahlavi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Inscriptional_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Inscriptional_Pahlavi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Inscriptional_Pahlavi}"
 );
-assert(
-  /^\p{Script_Extensions=Phli}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Phli}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Phli}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Phli}"
 );
-assert(
-  /^\p{scx=Inscriptional_Pahlavi}+$/u.test(matchSymbols),
-  "`\\p{scx=Inscriptional_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Inscriptional_Pahlavi}+$/u,
+  matchSymbols,
+  "\\p{scx=Inscriptional_Pahlavi}"
 );
-assert(
-  /^\p{scx=Phli}+$/u.test(matchSymbols),
-  "`\\p{scx=Phli}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Phli}+$/u,
+  matchSymbols,
+  "\\p{scx=Phli}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x010B80, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Inscriptional_Pahlavi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Inscriptional_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Inscriptional_Pahlavi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Inscriptional_Pahlavi}"
 );
-assert(
-  /^\P{Script_Extensions=Phli}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Phli}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Phli}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Phli}"
 );
-assert(
-  /^\P{scx=Inscriptional_Pahlavi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Inscriptional_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Inscriptional_Pahlavi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Inscriptional_Pahlavi}"
 );
-assert(
-  /^\P{scx=Phli}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Phli}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Phli}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Phli}"
 );

--- a/output/Script_Extensions_-_Inscriptional_Parthian.js
+++ b/output/Script_Extensions_-_Inscriptional_Parthian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x010B58, 0x010B5F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Inscriptional_Parthian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Inscriptional_Parthian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Inscriptional_Parthian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Inscriptional_Parthian}"
 );
-assert(
-  /^\p{Script_Extensions=Prti}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Prti}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Prti}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Prti}"
 );
-assert(
-  /^\p{scx=Inscriptional_Parthian}+$/u.test(matchSymbols),
-  "`\\p{scx=Inscriptional_Parthian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Inscriptional_Parthian}+$/u,
+  matchSymbols,
+  "\\p{scx=Inscriptional_Parthian}"
 );
-assert(
-  /^\p{scx=Prti}+$/u.test(matchSymbols),
-  "`\\p{scx=Prti}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Prti}+$/u,
+  matchSymbols,
+  "\\p{scx=Prti}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x010B60, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Inscriptional_Parthian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Inscriptional_Parthian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Inscriptional_Parthian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Inscriptional_Parthian}"
 );
-assert(
-  /^\P{Script_Extensions=Prti}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Prti}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Prti}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Prti}"
 );
-assert(
-  /^\P{scx=Inscriptional_Parthian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Inscriptional_Parthian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Inscriptional_Parthian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Inscriptional_Parthian}"
 );
-assert(
-  /^\P{scx=Prti}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Prti}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Prti}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Prti}"
 );

--- a/output/Script_Extensions_-_Javanese.js
+++ b/output/Script_Extensions_-_Javanese.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00A9DE, 0x00A9DF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Javanese}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Javanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Javanese}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Javanese}"
 );
-assert(
-  /^\p{Script_Extensions=Java}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Java}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Java}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Java}"
 );
-assert(
-  /^\p{scx=Javanese}+$/u.test(matchSymbols),
-  "`\\p{scx=Javanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Javanese}+$/u,
+  matchSymbols,
+  "\\p{scx=Javanese}"
 );
-assert(
-  /^\p{scx=Java}+$/u.test(matchSymbols),
-  "`\\p{scx=Java}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Java}+$/u,
+  matchSymbols,
+  "\\p{scx=Java}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Javanese}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Javanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Javanese}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Javanese}"
 );
-assert(
-  /^\P{Script_Extensions=Java}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Java}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Java}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Java}"
 );
-assert(
-  /^\P{scx=Javanese}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Javanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Javanese}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Javanese}"
 );
-assert(
-  /^\P{scx=Java}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Java}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Java}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Java}"
 );

--- a/output/Script_Extensions_-_Kaithi.js
+++ b/output/Script_Extensions_-_Kaithi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x011080, 0x0110C1]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Kaithi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Kaithi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Kaithi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Kaithi}"
 );
-assert(
-  /^\p{Script_Extensions=Kthi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Kthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Kthi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Kthi}"
 );
-assert(
-  /^\p{scx=Kaithi}+$/u.test(matchSymbols),
-  "`\\p{scx=Kaithi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Kaithi}+$/u,
+  matchSymbols,
+  "\\p{scx=Kaithi}"
 );
-assert(
-  /^\p{scx=Kthi}+$/u.test(matchSymbols),
-  "`\\p{scx=Kthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Kthi}+$/u,
+  matchSymbols,
+  "\\p{scx=Kthi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x0110C2, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Kaithi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Kaithi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Kaithi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Kaithi}"
 );
-assert(
-  /^\P{Script_Extensions=Kthi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Kthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Kthi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Kthi}"
 );
-assert(
-  /^\P{scx=Kaithi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Kaithi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Kaithi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Kaithi}"
 );
-assert(
-  /^\P{scx=Kthi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Kthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Kthi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Kthi}"
 );

--- a/output/Script_Extensions_-_Kannada.js
+++ b/output/Script_Extensions_-_Kannada.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -38,21 +38,25 @@ const matchSymbols = buildString({
     [0x00A830, 0x00A835]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Kannada}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Kannada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Kannada}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Kannada}"
 );
-assert(
-  /^\p{Script_Extensions=Knda}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Knda}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Knda}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Knda}"
 );
-assert(
-  /^\p{scx=Kannada}+$/u.test(matchSymbols),
-  "`\\p{scx=Kannada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Kannada}+$/u,
+  matchSymbols,
+  "\\p{scx=Kannada}"
 );
-assert(
-  /^\p{scx=Knda}+$/u.test(matchSymbols),
-  "`\\p{scx=Knda}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Knda}+$/u,
+  matchSymbols,
+  "\\p{scx=Knda}"
 );
 
 const nonMatchSymbols = buildString({
@@ -83,19 +87,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Kannada}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Kannada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Kannada}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Kannada}"
 );
-assert(
-  /^\P{Script_Extensions=Knda}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Knda}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Knda}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Knda}"
 );
-assert(
-  /^\P{scx=Kannada}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Kannada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Kannada}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Kannada}"
 );
-assert(
-  /^\P{scx=Knda}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Knda}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Knda}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Knda}"
 );

--- a/output/Script_Extensions_-_Katakana.js
+++ b/output/Script_Extensions_-_Katakana.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -33,21 +33,25 @@ const matchSymbols = buildString({
     [0x00FF61, 0x00FF9F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Katakana}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Katakana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Katakana}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Katakana}"
 );
-assert(
-  /^\p{Script_Extensions=Kana}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Kana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Kana}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Kana}"
 );
-assert(
-  /^\p{scx=Katakana}+$/u.test(matchSymbols),
-  "`\\p{scx=Katakana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Katakana}+$/u,
+  matchSymbols,
+  "\\p{scx=Katakana}"
 );
-assert(
-  /^\p{scx=Kana}+$/u.test(matchSymbols),
-  "`\\p{scx=Kana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Kana}+$/u,
+  matchSymbols,
+  "\\p{scx=Kana}"
 );
 
 const nonMatchSymbols = buildString({
@@ -73,19 +77,23 @@ const nonMatchSymbols = buildString({
     [0x01B001, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Katakana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Katakana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Katakana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Katakana}"
 );
-assert(
-  /^\P{Script_Extensions=Kana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Kana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Kana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Kana}"
 );
-assert(
-  /^\P{scx=Katakana}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Katakana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Katakana}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Katakana}"
 );
-assert(
-  /^\P{scx=Kana}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Kana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Kana}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Kana}"
 );

--- a/output/Script_Extensions_-_Kayah_Li.js
+++ b/output/Script_Extensions_-_Kayah_Li.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x00A900, 0x00A92F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Kayah_Li}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Kayah_Li}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Kayah_Li}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Kayah_Li}"
 );
-assert(
-  /^\p{Script_Extensions=Kali}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Kali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Kali}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Kali}"
 );
-assert(
-  /^\p{scx=Kayah_Li}+$/u.test(matchSymbols),
-  "`\\p{scx=Kayah_Li}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Kayah_Li}+$/u,
+  matchSymbols,
+  "\\p{scx=Kayah_Li}"
 );
-assert(
-  /^\p{scx=Kali}+$/u.test(matchSymbols),
-  "`\\p{scx=Kali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Kali}+$/u,
+  matchSymbols,
+  "\\p{scx=Kali}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Kayah_Li}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Kayah_Li}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Kayah_Li}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Kayah_Li}"
 );
-assert(
-  /^\P{Script_Extensions=Kali}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Kali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Kali}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Kali}"
 );
-assert(
-  /^\P{scx=Kayah_Li}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Kayah_Li}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Kayah_Li}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Kayah_Li}"
 );
-assert(
-  /^\P{scx=Kali}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Kali}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Kali}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Kali}"
 );

--- a/output/Script_Extensions_-_Kharoshthi.js
+++ b/output/Script_Extensions_-_Kharoshthi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -26,21 +26,25 @@ const matchSymbols = buildString({
     [0x010A50, 0x010A58]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Kharoshthi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Kharoshthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Kharoshthi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Kharoshthi}"
 );
-assert(
-  /^\p{Script_Extensions=Khar}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Khar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Khar}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Khar}"
 );
-assert(
-  /^\p{scx=Kharoshthi}+$/u.test(matchSymbols),
-  "`\\p{scx=Kharoshthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Kharoshthi}+$/u,
+  matchSymbols,
+  "\\p{scx=Kharoshthi}"
 );
-assert(
-  /^\p{scx=Khar}+$/u.test(matchSymbols),
-  "`\\p{scx=Khar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Khar}+$/u,
+  matchSymbols,
+  "\\p{scx=Khar}"
 );
 
 const nonMatchSymbols = buildString({
@@ -60,19 +64,23 @@ const nonMatchSymbols = buildString({
     [0x010A59, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Kharoshthi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Kharoshthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Kharoshthi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Kharoshthi}"
 );
-assert(
-  /^\P{Script_Extensions=Khar}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Khar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Khar}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Khar}"
 );
-assert(
-  /^\P{scx=Kharoshthi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Kharoshthi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Kharoshthi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Kharoshthi}"
 );
-assert(
-  /^\P{scx=Khar}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Khar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Khar}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Khar}"
 );

--- a/output/Script_Extensions_-_Khmer.js
+++ b/output/Script_Extensions_-_Khmer.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x0019E0, 0x0019FF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Khmer}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Khmer}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Khmer}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Khmer}"
 );
-assert(
-  /^\p{Script_Extensions=Khmr}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Khmr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Khmr}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Khmr}"
 );
-assert(
-  /^\p{scx=Khmer}+$/u.test(matchSymbols),
-  "`\\p{scx=Khmer}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Khmer}+$/u,
+  matchSymbols,
+  "\\p{scx=Khmer}"
 );
-assert(
-  /^\p{scx=Khmr}+$/u.test(matchSymbols),
-  "`\\p{scx=Khmr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Khmr}+$/u,
+  matchSymbols,
+  "\\p{scx=Khmr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Khmer}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Khmer}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Khmer}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Khmer}"
 );
-assert(
-  /^\P{Script_Extensions=Khmr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Khmr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Khmr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Khmr}"
 );
-assert(
-  /^\P{scx=Khmer}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Khmer}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Khmer}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Khmer}"
 );
-assert(
-  /^\P{scx=Khmr}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Khmr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Khmr}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Khmr}"
 );

--- a/output/Script_Extensions_-_Khojki.js
+++ b/output/Script_Extensions_-_Khojki.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x011213, 0x01123E]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Khojki}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Khojki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Khojki}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Khojki}"
 );
-assert(
-  /^\p{Script_Extensions=Khoj}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Khoj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Khoj}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Khoj}"
 );
-assert(
-  /^\p{scx=Khojki}+$/u.test(matchSymbols),
-  "`\\p{scx=Khojki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Khojki}+$/u,
+  matchSymbols,
+  "\\p{scx=Khojki}"
 );
-assert(
-  /^\p{scx=Khoj}+$/u.test(matchSymbols),
-  "`\\p{scx=Khoj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Khoj}+$/u,
+  matchSymbols,
+  "\\p{scx=Khoj}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x01123F, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Khojki}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Khojki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Khojki}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Khojki}"
 );
-assert(
-  /^\P{Script_Extensions=Khoj}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Khoj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Khoj}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Khoj}"
 );
-assert(
-  /^\P{scx=Khojki}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Khojki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Khojki}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Khojki}"
 );
-assert(
-  /^\P{scx=Khoj}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Khoj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Khoj}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Khoj}"
 );

--- a/output/Script_Extensions_-_Khudawadi.js
+++ b/output/Script_Extensions_-_Khudawadi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x0112F0, 0x0112F9]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Khudawadi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Khudawadi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Khudawadi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Khudawadi}"
 );
-assert(
-  /^\p{Script_Extensions=Sind}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sind}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sind}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sind}"
 );
-assert(
-  /^\p{scx=Khudawadi}+$/u.test(matchSymbols),
-  "`\\p{scx=Khudawadi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Khudawadi}+$/u,
+  matchSymbols,
+  "\\p{scx=Khudawadi}"
 );
-assert(
-  /^\p{scx=Sind}+$/u.test(matchSymbols),
-  "`\\p{scx=Sind}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sind}+$/u,
+  matchSymbols,
+  "\\p{scx=Sind}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x0112FA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Khudawadi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Khudawadi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Khudawadi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Khudawadi}"
 );
-assert(
-  /^\P{Script_Extensions=Sind}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sind}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sind}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sind}"
 );
-assert(
-  /^\P{scx=Khudawadi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Khudawadi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Khudawadi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Khudawadi}"
 );
-assert(
-  /^\P{scx=Sind}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sind}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sind}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sind}"
 );

--- a/output/Script_Extensions_-_Lao.js
+++ b/output/Script_Extensions_-_Lao.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -37,21 +37,25 @@ const matchSymbols = buildString({
     [0x000EDC, 0x000EDF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Lao}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lao}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lao}"
 );
-assert(
-  /^\p{Script_Extensions=Laoo}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Laoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Laoo}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Laoo}"
 );
-assert(
-  /^\p{scx=Lao}+$/u.test(matchSymbols),
-  "`\\p{scx=Lao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lao}+$/u,
+  matchSymbols,
+  "\\p{scx=Lao}"
 );
-assert(
-  /^\p{scx=Laoo}+$/u.test(matchSymbols),
-  "`\\p{scx=Laoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Laoo}+$/u,
+  matchSymbols,
+  "\\p{scx=Laoo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -81,19 +85,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Lao}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lao}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lao}"
 );
-assert(
-  /^\P{Script_Extensions=Laoo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Laoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Laoo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Laoo}"
 );
-assert(
-  /^\P{scx=Lao}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lao}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lao}"
 );
-assert(
-  /^\P{scx=Laoo}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Laoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Laoo}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Laoo}"
 );

--- a/output/Script_Extensions_-_Latin.js
+++ b/output/Script_Extensions_-_Latin.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -56,21 +56,25 @@ const matchSymbols = buildString({
     [0x00FF41, 0x00FF5A]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Latin}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Latin}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Latin}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Latin}"
 );
-assert(
-  /^\p{Script_Extensions=Latn}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Latn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Latn}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Latn}"
 );
-assert(
-  /^\p{scx=Latin}+$/u.test(matchSymbols),
-  "`\\p{scx=Latin}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Latin}+$/u,
+  matchSymbols,
+  "\\p{scx=Latin}"
 );
-assert(
-  /^\p{scx=Latn}+$/u.test(matchSymbols),
-  "`\\p{scx=Latn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Latn}+$/u,
+  matchSymbols,
+  "\\p{scx=Latn}"
 );
 
 const nonMatchSymbols = buildString({
@@ -119,19 +123,23 @@ const nonMatchSymbols = buildString({
     [0x00FF5B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Latin}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Latin}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Latin}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Latin}"
 );
-assert(
-  /^\P{Script_Extensions=Latn}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Latn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Latn}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Latn}"
 );
-assert(
-  /^\P{scx=Latin}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Latin}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Latin}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Latin}"
 );
-assert(
-  /^\P{scx=Latn}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Latn}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Latn}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Latn}"
 );

--- a/output/Script_Extensions_-_Lepcha.js
+++ b/output/Script_Extensions_-_Lepcha.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x001C4D, 0x001C4F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Lepcha}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lepcha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lepcha}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lepcha}"
 );
-assert(
-  /^\p{Script_Extensions=Lepc}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lepc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lepc}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lepc}"
 );
-assert(
-  /^\p{scx=Lepcha}+$/u.test(matchSymbols),
-  "`\\p{scx=Lepcha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lepcha}+$/u,
+  matchSymbols,
+  "\\p{scx=Lepcha}"
 );
-assert(
-  /^\p{scx=Lepc}+$/u.test(matchSymbols),
-  "`\\p{scx=Lepc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lepc}+$/u,
+  matchSymbols,
+  "\\p{scx=Lepc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Lepcha}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lepcha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lepcha}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lepcha}"
 );
-assert(
-  /^\P{Script_Extensions=Lepc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lepc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lepc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lepc}"
 );
-assert(
-  /^\P{scx=Lepcha}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lepcha}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lepcha}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lepcha}"
 );
-assert(
-  /^\P{scx=Lepc}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lepc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lepc}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lepc}"
 );

--- a/output/Script_Extensions_-_Limbu.js
+++ b/output/Script_Extensions_-_Limbu.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,21 +25,25 @@ const matchSymbols = buildString({
     [0x001944, 0x00194F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Limbu}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Limbu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Limbu}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Limbu}"
 );
-assert(
-  /^\p{Script_Extensions=Limb}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Limb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Limb}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Limb}"
 );
-assert(
-  /^\p{scx=Limbu}+$/u.test(matchSymbols),
-  "`\\p{scx=Limbu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Limbu}+$/u,
+  matchSymbols,
+  "\\p{scx=Limbu}"
 );
-assert(
-  /^\p{scx=Limb}+$/u.test(matchSymbols),
-  "`\\p{scx=Limb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Limb}+$/u,
+  matchSymbols,
+  "\\p{scx=Limb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -57,19 +61,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Limbu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Limbu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Limbu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Limbu}"
 );
-assert(
-  /^\P{Script_Extensions=Limb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Limb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Limb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Limb}"
 );
-assert(
-  /^\P{scx=Limbu}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Limbu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Limbu}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Limbu}"
 );
-assert(
-  /^\P{scx=Limb}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Limb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Limb}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Limb}"
 );

--- a/output/Script_Extensions_-_Linear_A.js
+++ b/output/Script_Extensions_-_Linear_A.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x010760, 0x010767]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Linear_A}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Linear_A}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Linear_A}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Linear_A}"
 );
-assert(
-  /^\p{Script_Extensions=Lina}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lina}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lina}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lina}"
 );
-assert(
-  /^\p{scx=Linear_A}+$/u.test(matchSymbols),
-  "`\\p{scx=Linear_A}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Linear_A}+$/u,
+  matchSymbols,
+  "\\p{scx=Linear_A}"
 );
-assert(
-  /^\p{scx=Lina}+$/u.test(matchSymbols),
-  "`\\p{scx=Lina}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lina}+$/u,
+  matchSymbols,
+  "\\p{scx=Lina}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x010768, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Linear_A}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Linear_A}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Linear_A}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Linear_A}"
 );
-assert(
-  /^\P{Script_Extensions=Lina}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lina}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lina}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lina}"
 );
-assert(
-  /^\P{scx=Linear_A}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Linear_A}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Linear_A}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Linear_A}"
 );
-assert(
-  /^\P{scx=Lina}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lina}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lina}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lina}"
 );

--- a/output/Script_Extensions_-_Linear_B.js
+++ b/output/Script_Extensions_-_Linear_B.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -28,21 +28,25 @@ const matchSymbols = buildString({
     [0x010137, 0x01013F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Linear_B}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Linear_B}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Linear_B}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Linear_B}"
 );
-assert(
-  /^\p{Script_Extensions=Linb}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Linb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Linb}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Linb}"
 );
-assert(
-  /^\p{scx=Linear_B}+$/u.test(matchSymbols),
-  "`\\p{scx=Linear_B}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Linear_B}+$/u,
+  matchSymbols,
+  "\\p{scx=Linear_B}"
 );
-assert(
-  /^\p{scx=Linb}+$/u.test(matchSymbols),
-  "`\\p{scx=Linb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Linb}+$/u,
+  matchSymbols,
+  "\\p{scx=Linb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -64,19 +68,23 @@ const nonMatchSymbols = buildString({
     [0x010140, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Linear_B}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Linear_B}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Linear_B}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Linear_B}"
 );
-assert(
-  /^\P{Script_Extensions=Linb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Linb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Linb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Linb}"
 );
-assert(
-  /^\P{scx=Linear_B}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Linear_B}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Linear_B}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Linear_B}"
 );
-assert(
-  /^\P{scx=Linb}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Linb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Linb}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Linb}"
 );

--- a/output/Script_Extensions_-_Lisu.js
+++ b/output/Script_Extensions_-_Lisu.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x00A4D0, 0x00A4FF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Lisu}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lisu}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lisu}"
 );
-assert(
-  /^\p{Script_Extensions=Lisu}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lisu}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lisu}"
 );
-assert(
-  /^\p{scx=Lisu}+$/u.test(matchSymbols),
-  "`\\p{scx=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lisu}+$/u,
+  matchSymbols,
+  "\\p{scx=Lisu}"
 );
-assert(
-  /^\p{scx=Lisu}+$/u.test(matchSymbols),
-  "`\\p{scx=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lisu}+$/u,
+  matchSymbols,
+  "\\p{scx=Lisu}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Lisu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lisu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lisu}"
 );
-assert(
-  /^\P{Script_Extensions=Lisu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lisu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lisu}"
 );
-assert(
-  /^\P{scx=Lisu}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lisu}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lisu}"
 );
-assert(
-  /^\P{scx=Lisu}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lisu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lisu}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lisu}"
 );

--- a/output/Script_Extensions_-_Lycian.js
+++ b/output/Script_Extensions_-_Lycian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010280, 0x01029C]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Lycian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lycian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lycian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lycian}"
 );
-assert(
-  /^\p{Script_Extensions=Lyci}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lyci}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lyci}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lyci}"
 );
-assert(
-  /^\p{scx=Lycian}+$/u.test(matchSymbols),
-  "`\\p{scx=Lycian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lycian}+$/u,
+  matchSymbols,
+  "\\p{scx=Lycian}"
 );
-assert(
-  /^\p{scx=Lyci}+$/u.test(matchSymbols),
-  "`\\p{scx=Lyci}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lyci}+$/u,
+  matchSymbols,
+  "\\p{scx=Lyci}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x01029D, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Lycian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lycian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lycian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lycian}"
 );
-assert(
-  /^\P{Script_Extensions=Lyci}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lyci}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lyci}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lyci}"
 );
-assert(
-  /^\P{scx=Lycian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lycian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lycian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lycian}"
 );
-assert(
-  /^\P{scx=Lyci}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lyci}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lyci}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lyci}"
 );

--- a/output/Script_Extensions_-_Lydian.js
+++ b/output/Script_Extensions_-_Lydian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010920, 0x010939]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Lydian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lydian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lydian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lydian}"
 );
-assert(
-  /^\p{Script_Extensions=Lydi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lydi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lydi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lydi}"
 );
-assert(
-  /^\p{scx=Lydian}+$/u.test(matchSymbols),
-  "`\\p{scx=Lydian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lydian}+$/u,
+  matchSymbols,
+  "\\p{scx=Lydian}"
 );
-assert(
-  /^\p{scx=Lydi}+$/u.test(matchSymbols),
-  "`\\p{scx=Lydi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lydi}+$/u,
+  matchSymbols,
+  "\\p{scx=Lydi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x010940, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Lydian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lydian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lydian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lydian}"
 );
-assert(
-  /^\P{Script_Extensions=Lydi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lydi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lydi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lydi}"
 );
-assert(
-  /^\P{scx=Lydian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lydian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lydian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lydian}"
 );
-assert(
-  /^\P{scx=Lydi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lydi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lydi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lydi}"
 );

--- a/output/Script_Extensions_-_Mahajani.js
+++ b/output/Script_Extensions_-_Mahajani.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x011150, 0x011176]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Mahajani}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mahajani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mahajani}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mahajani}"
 );
-assert(
-  /^\p{Script_Extensions=Mahj}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mahj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mahj}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mahj}"
 );
-assert(
-  /^\p{scx=Mahajani}+$/u.test(matchSymbols),
-  "`\\p{scx=Mahajani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mahajani}+$/u,
+  matchSymbols,
+  "\\p{scx=Mahajani}"
 );
-assert(
-  /^\p{scx=Mahj}+$/u.test(matchSymbols),
-  "`\\p{scx=Mahj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mahj}+$/u,
+  matchSymbols,
+  "\\p{scx=Mahj}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x011177, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Mahajani}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mahajani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mahajani}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mahajani}"
 );
-assert(
-  /^\P{Script_Extensions=Mahj}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mahj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mahj}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mahj}"
 );
-assert(
-  /^\P{scx=Mahajani}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mahajani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mahajani}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mahajani}"
 );
-assert(
-  /^\P{scx=Mahj}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mahj}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mahj}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mahj}"
 );

--- a/output/Script_Extensions_-_Malayalam.js
+++ b/output/Script_Extensions_-_Malayalam.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -31,21 +31,25 @@ const matchSymbols = buildString({
     [0x000D66, 0x000D7F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Malayalam}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Malayalam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Malayalam}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Malayalam}"
 );
-assert(
-  /^\p{Script_Extensions=Mlym}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mlym}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mlym}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mlym}"
 );
-assert(
-  /^\p{scx=Malayalam}+$/u.test(matchSymbols),
-  "`\\p{scx=Malayalam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Malayalam}+$/u,
+  matchSymbols,
+  "\\p{scx=Malayalam}"
 );
-assert(
-  /^\p{scx=Mlym}+$/u.test(matchSymbols),
-  "`\\p{scx=Mlym}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mlym}+$/u,
+  matchSymbols,
+  "\\p{scx=Mlym}"
 );
 
 const nonMatchSymbols = buildString({
@@ -69,19 +73,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Malayalam}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Malayalam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Malayalam}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Malayalam}"
 );
-assert(
-  /^\P{Script_Extensions=Mlym}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mlym}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mlym}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mlym}"
 );
-assert(
-  /^\P{scx=Malayalam}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Malayalam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Malayalam}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Malayalam}"
 );
-assert(
-  /^\P{scx=Mlym}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mlym}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mlym}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mlym}"
 );

--- a/output/Script_Extensions_-_Mandaic.js
+++ b/output/Script_Extensions_-_Mandaic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x000840, 0x00085B]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Mandaic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mandaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mandaic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mandaic}"
 );
-assert(
-  /^\p{Script_Extensions=Mand}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mand}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mand}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mand}"
 );
-assert(
-  /^\p{scx=Mandaic}+$/u.test(matchSymbols),
-  "`\\p{scx=Mandaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mandaic}+$/u,
+  matchSymbols,
+  "\\p{scx=Mandaic}"
 );
-assert(
-  /^\p{scx=Mand}+$/u.test(matchSymbols),
-  "`\\p{scx=Mand}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mand}+$/u,
+  matchSymbols,
+  "\\p{scx=Mand}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Mandaic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mandaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mandaic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mandaic}"
 );
-assert(
-  /^\P{Script_Extensions=Mand}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mand}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mand}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mand}"
 );
-assert(
-  /^\P{scx=Mandaic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mandaic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mandaic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mandaic}"
 );
-assert(
-  /^\P{scx=Mand}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mand}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mand}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mand}"
 );

--- a/output/Script_Extensions_-_Manichaean.js
+++ b/output/Script_Extensions_-_Manichaean.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x010AEB, 0x010AF6]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Manichaean}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Manichaean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Manichaean}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Manichaean}"
 );
-assert(
-  /^\p{Script_Extensions=Mani}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mani}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mani}"
 );
-assert(
-  /^\p{scx=Manichaean}+$/u.test(matchSymbols),
-  "`\\p{scx=Manichaean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Manichaean}+$/u,
+  matchSymbols,
+  "\\p{scx=Manichaean}"
 );
-assert(
-  /^\p{scx=Mani}+$/u.test(matchSymbols),
-  "`\\p{scx=Mani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mani}+$/u,
+  matchSymbols,
+  "\\p{scx=Mani}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x010AF7, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Manichaean}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Manichaean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Manichaean}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Manichaean}"
 );
-assert(
-  /^\P{Script_Extensions=Mani}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mani}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mani}"
 );
-assert(
-  /^\P{scx=Manichaean}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Manichaean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Manichaean}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Manichaean}"
 );
-assert(
-  /^\P{scx=Mani}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mani}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mani}"
 );

--- a/output/Script_Extensions_-_Marchen.js
+++ b/output/Script_Extensions_-_Marchen.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x011CA9, 0x011CB6]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Marchen}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Marchen}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Marchen}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Marchen}"
 );
-assert(
-  /^\p{Script_Extensions=Marc}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Marc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Marc}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Marc}"
 );
-assert(
-  /^\p{scx=Marchen}+$/u.test(matchSymbols),
-  "`\\p{scx=Marchen}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Marchen}+$/u,
+  matchSymbols,
+  "\\p{scx=Marchen}"
 );
-assert(
-  /^\p{scx=Marc}+$/u.test(matchSymbols),
-  "`\\p{scx=Marc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Marc}+$/u,
+  matchSymbols,
+  "\\p{scx=Marc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x011CB7, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Marchen}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Marchen}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Marchen}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Marchen}"
 );
-assert(
-  /^\P{Script_Extensions=Marc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Marc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Marc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Marc}"
 );
-assert(
-  /^\P{scx=Marchen}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Marchen}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Marchen}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Marchen}"
 );
-assert(
-  /^\P{scx=Marc}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Marc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Marc}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Marc}"
 );

--- a/output/Script_Extensions_-_Meetei_Mayek.js
+++ b/output/Script_Extensions_-_Meetei_Mayek.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00ABF0, 0x00ABF9]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Meetei_Mayek}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Meetei_Mayek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Meetei_Mayek}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Meetei_Mayek}"
 );
-assert(
-  /^\p{Script_Extensions=Mtei}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mtei}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mtei}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mtei}"
 );
-assert(
-  /^\p{scx=Meetei_Mayek}+$/u.test(matchSymbols),
-  "`\\p{scx=Meetei_Mayek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Meetei_Mayek}+$/u,
+  matchSymbols,
+  "\\p{scx=Meetei_Mayek}"
 );
-assert(
-  /^\p{scx=Mtei}+$/u.test(matchSymbols),
-  "`\\p{scx=Mtei}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mtei}+$/u,
+  matchSymbols,
+  "\\p{scx=Mtei}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Meetei_Mayek}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Meetei_Mayek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Meetei_Mayek}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Meetei_Mayek}"
 );
-assert(
-  /^\P{Script_Extensions=Mtei}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mtei}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mtei}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mtei}"
 );
-assert(
-  /^\P{scx=Meetei_Mayek}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Meetei_Mayek}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Meetei_Mayek}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Meetei_Mayek}"
 );
-assert(
-  /^\P{scx=Mtei}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mtei}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mtei}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mtei}"
 );

--- a/output/Script_Extensions_-_Mende_Kikakui.js
+++ b/output/Script_Extensions_-_Mende_Kikakui.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x01E8C7, 0x01E8D6]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Mende_Kikakui}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mende_Kikakui}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mende_Kikakui}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mende_Kikakui}"
 );
-assert(
-  /^\p{Script_Extensions=Mend}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mend}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mend}"
 );
-assert(
-  /^\p{scx=Mende_Kikakui}+$/u.test(matchSymbols),
-  "`\\p{scx=Mende_Kikakui}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mende_Kikakui}+$/u,
+  matchSymbols,
+  "\\p{scx=Mende_Kikakui}"
 );
-assert(
-  /^\p{scx=Mend}+$/u.test(matchSymbols),
-  "`\\p{scx=Mend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mend}+$/u,
+  matchSymbols,
+  "\\p{scx=Mend}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x01E8D7, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Mende_Kikakui}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mende_Kikakui}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mende_Kikakui}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mende_Kikakui}"
 );
-assert(
-  /^\P{Script_Extensions=Mend}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mend}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mend}"
 );
-assert(
-  /^\P{scx=Mende_Kikakui}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mende_Kikakui}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mende_Kikakui}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mende_Kikakui}"
 );
-assert(
-  /^\P{scx=Mend}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mend}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mend}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mend}"
 );

--- a/output/Script_Extensions_-_Meroitic_Cursive.js
+++ b/output/Script_Extensions_-_Meroitic_Cursive.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x0109D2, 0x0109FF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Meroitic_Cursive}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Meroitic_Cursive}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Meroitic_Cursive}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Meroitic_Cursive}"
 );
-assert(
-  /^\p{Script_Extensions=Merc}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Merc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Merc}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Merc}"
 );
-assert(
-  /^\p{scx=Meroitic_Cursive}+$/u.test(matchSymbols),
-  "`\\p{scx=Meroitic_Cursive}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Meroitic_Cursive}+$/u,
+  matchSymbols,
+  "\\p{scx=Meroitic_Cursive}"
 );
-assert(
-  /^\p{scx=Merc}+$/u.test(matchSymbols),
-  "`\\p{scx=Merc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Merc}+$/u,
+  matchSymbols,
+  "\\p{scx=Merc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x010A00, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Meroitic_Cursive}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Meroitic_Cursive}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Meroitic_Cursive}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Meroitic_Cursive}"
 );
-assert(
-  /^\P{Script_Extensions=Merc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Merc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Merc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Merc}"
 );
-assert(
-  /^\P{scx=Meroitic_Cursive}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Meroitic_Cursive}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Meroitic_Cursive}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Meroitic_Cursive}"
 );
-assert(
-  /^\P{scx=Merc}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Merc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Merc}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Merc}"
 );

--- a/output/Script_Extensions_-_Meroitic_Hieroglyphs.js
+++ b/output/Script_Extensions_-_Meroitic_Hieroglyphs.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010980, 0x01099F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Meroitic_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Meroitic_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Meroitic_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Meroitic_Hieroglyphs}"
 );
-assert(
-  /^\p{Script_Extensions=Mero}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mero}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mero}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mero}"
 );
-assert(
-  /^\p{scx=Meroitic_Hieroglyphs}+$/u.test(matchSymbols),
-  "`\\p{scx=Meroitic_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Meroitic_Hieroglyphs}+$/u,
+  matchSymbols,
+  "\\p{scx=Meroitic_Hieroglyphs}"
 );
-assert(
-  /^\p{scx=Mero}+$/u.test(matchSymbols),
-  "`\\p{scx=Mero}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mero}+$/u,
+  matchSymbols,
+  "\\p{scx=Mero}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x0109A0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Meroitic_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Meroitic_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Meroitic_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Meroitic_Hieroglyphs}"
 );
-assert(
-  /^\P{Script_Extensions=Mero}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mero}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mero}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mero}"
 );
-assert(
-  /^\P{scx=Meroitic_Hieroglyphs}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Meroitic_Hieroglyphs}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Meroitic_Hieroglyphs}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Meroitic_Hieroglyphs}"
 );
-assert(
-  /^\P{scx=Mero}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mero}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mero}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mero}"
 );

--- a/output/Script_Extensions_-_Miao.js
+++ b/output/Script_Extensions_-_Miao.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x016F8F, 0x016F9F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Miao}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Miao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Miao}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Miao}"
 );
-assert(
-  /^\p{Script_Extensions=Plrd}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Plrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Plrd}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Plrd}"
 );
-assert(
-  /^\p{scx=Miao}+$/u.test(matchSymbols),
-  "`\\p{scx=Miao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Miao}+$/u,
+  matchSymbols,
+  "\\p{scx=Miao}"
 );
-assert(
-  /^\p{scx=Plrd}+$/u.test(matchSymbols),
-  "`\\p{scx=Plrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Plrd}+$/u,
+  matchSymbols,
+  "\\p{scx=Plrd}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x016FA0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Miao}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Miao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Miao}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Miao}"
 );
-assert(
-  /^\P{Script_Extensions=Plrd}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Plrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Plrd}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Plrd}"
 );
-assert(
-  /^\P{scx=Miao}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Miao}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Miao}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Miao}"
 );
-assert(
-  /^\P{scx=Plrd}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Plrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Plrd}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Plrd}"
 );

--- a/output/Script_Extensions_-_Modi.js
+++ b/output/Script_Extensions_-_Modi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x011650, 0x011659]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Modi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Modi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Modi}"
 );
-assert(
-  /^\p{Script_Extensions=Modi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Modi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Modi}"
 );
-assert(
-  /^\p{scx=Modi}+$/u.test(matchSymbols),
-  "`\\p{scx=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Modi}+$/u,
+  matchSymbols,
+  "\\p{scx=Modi}"
 );
-assert(
-  /^\p{scx=Modi}+$/u.test(matchSymbols),
-  "`\\p{scx=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Modi}+$/u,
+  matchSymbols,
+  "\\p{scx=Modi}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x01165A, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Modi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Modi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Modi}"
 );
-assert(
-  /^\P{Script_Extensions=Modi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Modi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Modi}"
 );
-assert(
-  /^\P{scx=Modi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Modi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Modi}"
 );
-assert(
-  /^\P{scx=Modi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Modi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Modi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Modi}"
 );

--- a/output/Script_Extensions_-_Mongolian.js
+++ b/output/Script_Extensions_-_Mongolian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x011660, 0x01166C]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Mongolian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mongolian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mongolian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mongolian}"
 );
-assert(
-  /^\p{Script_Extensions=Mong}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mong}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mong}"
 );
-assert(
-  /^\p{scx=Mongolian}+$/u.test(matchSymbols),
-  "`\\p{scx=Mongolian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mongolian}+$/u,
+  matchSymbols,
+  "\\p{scx=Mongolian}"
 );
-assert(
-  /^\p{scx=Mong}+$/u.test(matchSymbols),
-  "`\\p{scx=Mong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mong}+$/u,
+  matchSymbols,
+  "\\p{scx=Mong}"
 );
 
 const nonMatchSymbols = buildString({
@@ -54,19 +58,23 @@ const nonMatchSymbols = buildString({
     [0x01166D, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Mongolian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mongolian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mongolian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mongolian}"
 );
-assert(
-  /^\P{Script_Extensions=Mong}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mong}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mong}"
 );
-assert(
-  /^\P{scx=Mongolian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mongolian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mongolian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mongolian}"
 );
-assert(
-  /^\P{scx=Mong}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mong}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mong}"
 );

--- a/output/Script_Extensions_-_Mro.js
+++ b/output/Script_Extensions_-_Mro.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x016A6E, 0x016A6F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Mro}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mro}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mro}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mro}"
 );
-assert(
-  /^\p{Script_Extensions=Mroo}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mroo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mroo}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mroo}"
 );
-assert(
-  /^\p{scx=Mro}+$/u.test(matchSymbols),
-  "`\\p{scx=Mro}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mro}+$/u,
+  matchSymbols,
+  "\\p{scx=Mro}"
 );
-assert(
-  /^\p{scx=Mroo}+$/u.test(matchSymbols),
-  "`\\p{scx=Mroo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mroo}+$/u,
+  matchSymbols,
+  "\\p{scx=Mroo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x016A70, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Mro}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mro}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mro}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mro}"
 );
-assert(
-  /^\P{Script_Extensions=Mroo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mroo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mroo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mroo}"
 );
-assert(
-  /^\P{scx=Mro}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mro}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mro}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mro}"
 );
-assert(
-  /^\P{scx=Mroo}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mroo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mroo}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mroo}"
 );

--- a/output/Script_Extensions_-_Multani.js
+++ b/output/Script_Extensions_-_Multani.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,21 +25,25 @@ const matchSymbols = buildString({
     [0x01129F, 0x0112A9]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Multani}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Multani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Multani}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Multani}"
 );
-assert(
-  /^\p{Script_Extensions=Mult}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mult}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mult}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mult}"
 );
-assert(
-  /^\p{scx=Multani}+$/u.test(matchSymbols),
-  "`\\p{scx=Multani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Multani}+$/u,
+  matchSymbols,
+  "\\p{scx=Multani}"
 );
-assert(
-  /^\p{scx=Mult}+$/u.test(matchSymbols),
-  "`\\p{scx=Mult}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mult}+$/u,
+  matchSymbols,
+  "\\p{scx=Mult}"
 );
 
 const nonMatchSymbols = buildString({
@@ -57,19 +61,23 @@ const nonMatchSymbols = buildString({
     [0x0112AA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Multani}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Multani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Multani}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Multani}"
 );
-assert(
-  /^\P{Script_Extensions=Mult}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mult}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mult}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mult}"
 );
-assert(
-  /^\P{scx=Multani}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Multani}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Multani}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Multani}"
 );
-assert(
-  /^\P{scx=Mult}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mult}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mult}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mult}"
 );

--- a/output/Script_Extensions_-_Myanmar.js
+++ b/output/Script_Extensions_-_Myanmar.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x00AA60, 0x00AA7F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Myanmar}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Myanmar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Myanmar}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Myanmar}"
 );
-assert(
-  /^\p{Script_Extensions=Mymr}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Mymr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Mymr}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Mymr}"
 );
-assert(
-  /^\p{scx=Myanmar}+$/u.test(matchSymbols),
-  "`\\p{scx=Myanmar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Myanmar}+$/u,
+  matchSymbols,
+  "\\p{scx=Myanmar}"
 );
-assert(
-  /^\p{scx=Mymr}+$/u.test(matchSymbols),
-  "`\\p{scx=Mymr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Mymr}+$/u,
+  matchSymbols,
+  "\\p{scx=Mymr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Myanmar}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Myanmar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Myanmar}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Myanmar}"
 );
-assert(
-  /^\P{Script_Extensions=Mymr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Mymr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Mymr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Mymr}"
 );
-assert(
-  /^\P{scx=Myanmar}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Myanmar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Myanmar}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Myanmar}"
 );
-assert(
-  /^\P{scx=Mymr}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Mymr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Mymr}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Mymr}"
 );

--- a/output/Script_Extensions_-_Nabataean.js
+++ b/output/Script_Extensions_-_Nabataean.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0108A7, 0x0108AF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Nabataean}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Nabataean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Nabataean}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Nabataean}"
 );
-assert(
-  /^\p{Script_Extensions=Nbat}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Nbat}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Nbat}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Nbat}"
 );
-assert(
-  /^\p{scx=Nabataean}+$/u.test(matchSymbols),
-  "`\\p{scx=Nabataean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Nabataean}+$/u,
+  matchSymbols,
+  "\\p{scx=Nabataean}"
 );
-assert(
-  /^\p{scx=Nbat}+$/u.test(matchSymbols),
-  "`\\p{scx=Nbat}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Nbat}+$/u,
+  matchSymbols,
+  "\\p{scx=Nbat}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0108B0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Nabataean}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Nabataean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Nabataean}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Nabataean}"
 );
-assert(
-  /^\P{Script_Extensions=Nbat}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Nbat}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Nbat}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Nbat}"
 );
-assert(
-  /^\P{scx=Nabataean}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Nabataean}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Nabataean}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Nabataean}"
 );
-assert(
-  /^\P{scx=Nbat}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Nbat}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Nbat}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Nbat}"
 );

--- a/output/Script_Extensions_-_New_Tai_Lue.js
+++ b/output/Script_Extensions_-_New_Tai_Lue.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x0019DE, 0x0019DF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=New_Tai_Lue}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=New_Tai_Lue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=New_Tai_Lue}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=New_Tai_Lue}"
 );
-assert(
-  /^\p{Script_Extensions=Talu}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Talu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Talu}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Talu}"
 );
-assert(
-  /^\p{scx=New_Tai_Lue}+$/u.test(matchSymbols),
-  "`\\p{scx=New_Tai_Lue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=New_Tai_Lue}+$/u,
+  matchSymbols,
+  "\\p{scx=New_Tai_Lue}"
 );
-assert(
-  /^\p{scx=Talu}+$/u.test(matchSymbols),
-  "`\\p{scx=Talu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Talu}+$/u,
+  matchSymbols,
+  "\\p{scx=Talu}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=New_Tai_Lue}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=New_Tai_Lue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=New_Tai_Lue}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=New_Tai_Lue}"
 );
-assert(
-  /^\P{Script_Extensions=Talu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Talu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Talu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Talu}"
 );
-assert(
-  /^\P{scx=New_Tai_Lue}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=New_Tai_Lue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=New_Tai_Lue}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=New_Tai_Lue}"
 );
-assert(
-  /^\P{scx=Talu}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Talu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Talu}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Talu}"
 );

--- a/output/Script_Extensions_-_Newa.js
+++ b/output/Script_Extensions_-_Newa.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x011400, 0x011459]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Newa}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Newa}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Newa}"
 );
-assert(
-  /^\p{Script_Extensions=Newa}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Newa}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Newa}"
 );
-assert(
-  /^\p{scx=Newa}+$/u.test(matchSymbols),
-  "`\\p{scx=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Newa}+$/u,
+  matchSymbols,
+  "\\p{scx=Newa}"
 );
-assert(
-  /^\p{scx=Newa}+$/u.test(matchSymbols),
-  "`\\p{scx=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Newa}+$/u,
+  matchSymbols,
+  "\\p{scx=Newa}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x01145E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Newa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Newa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Newa}"
 );
-assert(
-  /^\P{Script_Extensions=Newa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Newa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Newa}"
 );
-assert(
-  /^\P{scx=Newa}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Newa}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Newa}"
 );
-assert(
-  /^\P{scx=Newa}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Newa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Newa}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Newa}"
 );

--- a/output/Script_Extensions_-_Nko.js
+++ b/output/Script_Extensions_-_Nko.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x0007C0, 0x0007FA]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Nko}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Nko}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Nko}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Nko}"
 );
-assert(
-  /^\p{Script_Extensions=Nkoo}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Nkoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Nkoo}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Nkoo}"
 );
-assert(
-  /^\p{scx=Nko}+$/u.test(matchSymbols),
-  "`\\p{scx=Nko}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Nko}+$/u,
+  matchSymbols,
+  "\\p{scx=Nko}"
 );
-assert(
-  /^\p{scx=Nkoo}+$/u.test(matchSymbols),
-  "`\\p{scx=Nkoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Nkoo}+$/u,
+  matchSymbols,
+  "\\p{scx=Nkoo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Nko}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Nko}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Nko}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Nko}"
 );
-assert(
-  /^\P{Script_Extensions=Nkoo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Nkoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Nkoo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Nkoo}"
 );
-assert(
-  /^\P{scx=Nko}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Nko}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Nko}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Nko}"
 );
-assert(
-  /^\P{scx=Nkoo}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Nkoo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Nkoo}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Nkoo}"
 );

--- a/output/Script_Extensions_-_Ogham.js
+++ b/output/Script_Extensions_-_Ogham.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x001680, 0x00169C]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Ogham}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ogham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ogham}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ogham}"
 );
-assert(
-  /^\p{Script_Extensions=Ogam}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ogam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ogam}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ogam}"
 );
-assert(
-  /^\p{scx=Ogham}+$/u.test(matchSymbols),
-  "`\\p{scx=Ogham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ogham}+$/u,
+  matchSymbols,
+  "\\p{scx=Ogham}"
 );
-assert(
-  /^\p{scx=Ogam}+$/u.test(matchSymbols),
-  "`\\p{scx=Ogam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ogam}+$/u,
+  matchSymbols,
+  "\\p{scx=Ogam}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Ogham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ogham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ogham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ogham}"
 );
-assert(
-  /^\P{Script_Extensions=Ogam}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ogam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ogam}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ogam}"
 );
-assert(
-  /^\P{scx=Ogham}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ogham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ogham}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ogham}"
 );
-assert(
-  /^\P{scx=Ogam}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ogam}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ogam}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ogam}"
 );

--- a/output/Script_Extensions_-_Ol_Chiki.js
+++ b/output/Script_Extensions_-_Ol_Chiki.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x001C50, 0x001C7F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Ol_Chiki}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ol_Chiki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ol_Chiki}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ol_Chiki}"
 );
-assert(
-  /^\p{Script_Extensions=Olck}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Olck}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Olck}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Olck}"
 );
-assert(
-  /^\p{scx=Ol_Chiki}+$/u.test(matchSymbols),
-  "`\\p{scx=Ol_Chiki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ol_Chiki}+$/u,
+  matchSymbols,
+  "\\p{scx=Ol_Chiki}"
 );
-assert(
-  /^\p{scx=Olck}+$/u.test(matchSymbols),
-  "`\\p{scx=Olck}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Olck}+$/u,
+  matchSymbols,
+  "\\p{scx=Olck}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Ol_Chiki}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ol_Chiki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ol_Chiki}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ol_Chiki}"
 );
-assert(
-  /^\P{Script_Extensions=Olck}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Olck}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Olck}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Olck}"
 );
-assert(
-  /^\P{scx=Ol_Chiki}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ol_Chiki}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ol_Chiki}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ol_Chiki}"
 );
-assert(
-  /^\P{scx=Olck}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Olck}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Olck}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Olck}"
 );

--- a/output/Script_Extensions_-_Old_Hungarian.js
+++ b/output/Script_Extensions_-_Old_Hungarian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010CFA, 0x010CFF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Old_Hungarian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Old_Hungarian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Old_Hungarian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Old_Hungarian}"
 );
-assert(
-  /^\p{Script_Extensions=Hung}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hung}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hung}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hung}"
 );
-assert(
-  /^\p{scx=Old_Hungarian}+$/u.test(matchSymbols),
-  "`\\p{scx=Old_Hungarian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Old_Hungarian}+$/u,
+  matchSymbols,
+  "\\p{scx=Old_Hungarian}"
 );
-assert(
-  /^\p{scx=Hung}+$/u.test(matchSymbols),
-  "`\\p{scx=Hung}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hung}+$/u,
+  matchSymbols,
+  "\\p{scx=Hung}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x010D00, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Old_Hungarian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Old_Hungarian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Old_Hungarian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Old_Hungarian}"
 );
-assert(
-  /^\P{Script_Extensions=Hung}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hung}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hung}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hung}"
 );
-assert(
-  /^\P{scx=Old_Hungarian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Old_Hungarian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Old_Hungarian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Old_Hungarian}"
 );
-assert(
-  /^\P{scx=Hung}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hung}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hung}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hung}"
 );

--- a/output/Script_Extensions_-_Old_Italic.js
+++ b/output/Script_Extensions_-_Old_Italic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010300, 0x010323]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Old_Italic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Old_Italic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Old_Italic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Old_Italic}"
 );
-assert(
-  /^\p{Script_Extensions=Ital}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ital}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ital}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ital}"
 );
-assert(
-  /^\p{scx=Old_Italic}+$/u.test(matchSymbols),
-  "`\\p{scx=Old_Italic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Old_Italic}+$/u,
+  matchSymbols,
+  "\\p{scx=Old_Italic}"
 );
-assert(
-  /^\p{scx=Ital}+$/u.test(matchSymbols),
-  "`\\p{scx=Ital}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ital}+$/u,
+  matchSymbols,
+  "\\p{scx=Ital}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010324, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Old_Italic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Old_Italic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Old_Italic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Old_Italic}"
 );
-assert(
-  /^\P{Script_Extensions=Ital}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ital}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ital}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ital}"
 );
-assert(
-  /^\P{scx=Old_Italic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Old_Italic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Old_Italic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Old_Italic}"
 );
-assert(
-  /^\P{scx=Ital}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ital}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ital}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ital}"
 );

--- a/output/Script_Extensions_-_Old_North_Arabian.js
+++ b/output/Script_Extensions_-_Old_North_Arabian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010A80, 0x010A9F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Old_North_Arabian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Old_North_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Old_North_Arabian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Old_North_Arabian}"
 );
-assert(
-  /^\p{Script_Extensions=Narb}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Narb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Narb}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Narb}"
 );
-assert(
-  /^\p{scx=Old_North_Arabian}+$/u.test(matchSymbols),
-  "`\\p{scx=Old_North_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Old_North_Arabian}+$/u,
+  matchSymbols,
+  "\\p{scx=Old_North_Arabian}"
 );
-assert(
-  /^\p{scx=Narb}+$/u.test(matchSymbols),
-  "`\\p{scx=Narb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Narb}+$/u,
+  matchSymbols,
+  "\\p{scx=Narb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010AA0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Old_North_Arabian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Old_North_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Old_North_Arabian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Old_North_Arabian}"
 );
-assert(
-  /^\P{Script_Extensions=Narb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Narb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Narb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Narb}"
 );
-assert(
-  /^\P{scx=Old_North_Arabian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Old_North_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Old_North_Arabian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Old_North_Arabian}"
 );
-assert(
-  /^\P{scx=Narb}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Narb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Narb}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Narb}"
 );

--- a/output/Script_Extensions_-_Old_Permic.js
+++ b/output/Script_Extensions_-_Old_Permic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010350, 0x01037A]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Old_Permic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Old_Permic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Old_Permic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Old_Permic}"
 );
-assert(
-  /^\p{Script_Extensions=Perm}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Perm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Perm}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Perm}"
 );
-assert(
-  /^\p{scx=Old_Permic}+$/u.test(matchSymbols),
-  "`\\p{scx=Old_Permic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Old_Permic}+$/u,
+  matchSymbols,
+  "\\p{scx=Old_Permic}"
 );
-assert(
-  /^\p{scx=Perm}+$/u.test(matchSymbols),
-  "`\\p{scx=Perm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Perm}+$/u,
+  matchSymbols,
+  "\\p{scx=Perm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x01037B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Old_Permic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Old_Permic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Old_Permic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Old_Permic}"
 );
-assert(
-  /^\P{Script_Extensions=Perm}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Perm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Perm}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Perm}"
 );
-assert(
-  /^\P{scx=Old_Permic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Old_Permic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Old_Permic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Old_Permic}"
 );
-assert(
-  /^\P{scx=Perm}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Perm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Perm}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Perm}"
 );

--- a/output/Script_Extensions_-_Old_Persian.js
+++ b/output/Script_Extensions_-_Old_Persian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0103C8, 0x0103D5]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Old_Persian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Old_Persian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Old_Persian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Old_Persian}"
 );
-assert(
-  /^\p{Script_Extensions=Xpeo}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Xpeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Xpeo}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Xpeo}"
 );
-assert(
-  /^\p{scx=Old_Persian}+$/u.test(matchSymbols),
-  "`\\p{scx=Old_Persian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Old_Persian}+$/u,
+  matchSymbols,
+  "\\p{scx=Old_Persian}"
 );
-assert(
-  /^\p{scx=Xpeo}+$/u.test(matchSymbols),
-  "`\\p{scx=Xpeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Xpeo}+$/u,
+  matchSymbols,
+  "\\p{scx=Xpeo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0103D6, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Old_Persian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Old_Persian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Old_Persian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Old_Persian}"
 );
-assert(
-  /^\P{Script_Extensions=Xpeo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Xpeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Xpeo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Xpeo}"
 );
-assert(
-  /^\P{scx=Old_Persian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Old_Persian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Old_Persian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Old_Persian}"
 );
-assert(
-  /^\P{scx=Xpeo}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Xpeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Xpeo}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Xpeo}"
 );

--- a/output/Script_Extensions_-_Old_South_Arabian.js
+++ b/output/Script_Extensions_-_Old_South_Arabian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010A60, 0x010A7F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Old_South_Arabian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Old_South_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Old_South_Arabian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Old_South_Arabian}"
 );
-assert(
-  /^\p{Script_Extensions=Sarb}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sarb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sarb}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sarb}"
 );
-assert(
-  /^\p{scx=Old_South_Arabian}+$/u.test(matchSymbols),
-  "`\\p{scx=Old_South_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Old_South_Arabian}+$/u,
+  matchSymbols,
+  "\\p{scx=Old_South_Arabian}"
 );
-assert(
-  /^\p{scx=Sarb}+$/u.test(matchSymbols),
-  "`\\p{scx=Sarb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sarb}+$/u,
+  matchSymbols,
+  "\\p{scx=Sarb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010A80, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Old_South_Arabian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Old_South_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Old_South_Arabian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Old_South_Arabian}"
 );
-assert(
-  /^\P{Script_Extensions=Sarb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sarb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sarb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sarb}"
 );
-assert(
-  /^\P{scx=Old_South_Arabian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Old_South_Arabian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Old_South_Arabian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Old_South_Arabian}"
 );
-assert(
-  /^\P{scx=Sarb}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sarb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sarb}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sarb}"
 );

--- a/output/Script_Extensions_-_Old_Turkic.js
+++ b/output/Script_Extensions_-_Old_Turkic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010C00, 0x010C48]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Old_Turkic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Old_Turkic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Old_Turkic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Old_Turkic}"
 );
-assert(
-  /^\p{Script_Extensions=Orkh}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Orkh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Orkh}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Orkh}"
 );
-assert(
-  /^\p{scx=Old_Turkic}+$/u.test(matchSymbols),
-  "`\\p{scx=Old_Turkic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Old_Turkic}+$/u,
+  matchSymbols,
+  "\\p{scx=Old_Turkic}"
 );
-assert(
-  /^\p{scx=Orkh}+$/u.test(matchSymbols),
-  "`\\p{scx=Orkh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Orkh}+$/u,
+  matchSymbols,
+  "\\p{scx=Orkh}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010C49, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Old_Turkic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Old_Turkic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Old_Turkic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Old_Turkic}"
 );
-assert(
-  /^\P{Script_Extensions=Orkh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Orkh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Orkh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Orkh}"
 );
-assert(
-  /^\P{scx=Old_Turkic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Old_Turkic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Old_Turkic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Old_Turkic}"
 );
-assert(
-  /^\P{scx=Orkh}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Orkh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Orkh}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Orkh}"
 );

--- a/output/Script_Extensions_-_Oriya.js
+++ b/output/Script_Extensions_-_Oriya.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -34,21 +34,25 @@ const matchSymbols = buildString({
     [0x000B66, 0x000B77]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Oriya}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Oriya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Oriya}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Oriya}"
 );
-assert(
-  /^\p{Script_Extensions=Orya}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Orya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Orya}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Orya}"
 );
-assert(
-  /^\p{scx=Oriya}+$/u.test(matchSymbols),
-  "`\\p{scx=Oriya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Oriya}+$/u,
+  matchSymbols,
+  "\\p{scx=Oriya}"
 );
-assert(
-  /^\p{scx=Orya}+$/u.test(matchSymbols),
-  "`\\p{scx=Orya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Orya}+$/u,
+  matchSymbols,
+  "\\p{scx=Orya}"
 );
 
 const nonMatchSymbols = buildString({
@@ -76,19 +80,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Oriya}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Oriya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Oriya}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Oriya}"
 );
-assert(
-  /^\P{Script_Extensions=Orya}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Orya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Orya}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Orya}"
 );
-assert(
-  /^\P{scx=Oriya}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Oriya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Oriya}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Oriya}"
 );
-assert(
-  /^\P{scx=Orya}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Orya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Orya}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Orya}"
 );

--- a/output/Script_Extensions_-_Osage.js
+++ b/output/Script_Extensions_-_Osage.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0104D8, 0x0104FB]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Osage}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Osage}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Osage}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Osage}"
 );
-assert(
-  /^\p{Script_Extensions=Osge}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Osge}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Osge}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Osge}"
 );
-assert(
-  /^\p{scx=Osage}+$/u.test(matchSymbols),
-  "`\\p{scx=Osage}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Osage}+$/u,
+  matchSymbols,
+  "\\p{scx=Osage}"
 );
-assert(
-  /^\p{scx=Osge}+$/u.test(matchSymbols),
-  "`\\p{scx=Osge}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Osge}+$/u,
+  matchSymbols,
+  "\\p{scx=Osge}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0104FC, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Osage}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Osage}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Osage}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Osage}"
 );
-assert(
-  /^\P{Script_Extensions=Osge}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Osge}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Osge}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Osge}"
 );
-assert(
-  /^\P{scx=Osage}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Osage}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Osage}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Osage}"
 );
-assert(
-  /^\P{scx=Osge}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Osge}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Osge}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Osge}"
 );

--- a/output/Script_Extensions_-_Osmanya.js
+++ b/output/Script_Extensions_-_Osmanya.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0104A0, 0x0104A9]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Osmanya}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Osmanya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Osmanya}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Osmanya}"
 );
-assert(
-  /^\p{Script_Extensions=Osma}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Osma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Osma}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Osma}"
 );
-assert(
-  /^\p{scx=Osmanya}+$/u.test(matchSymbols),
-  "`\\p{scx=Osmanya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Osmanya}+$/u,
+  matchSymbols,
+  "\\p{scx=Osmanya}"
 );
-assert(
-  /^\p{scx=Osma}+$/u.test(matchSymbols),
-  "`\\p{scx=Osma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Osma}+$/u,
+  matchSymbols,
+  "\\p{scx=Osma}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0104AA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Osmanya}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Osmanya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Osmanya}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Osmanya}"
 );
-assert(
-  /^\P{Script_Extensions=Osma}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Osma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Osma}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Osma}"
 );
-assert(
-  /^\P{scx=Osmanya}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Osmanya}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Osmanya}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Osmanya}"
 );
-assert(
-  /^\P{scx=Osma}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Osma}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Osma}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Osma}"
 );

--- a/output/Script_Extensions_-_Pahawh_Hmong.js
+++ b/output/Script_Extensions_-_Pahawh_Hmong.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x016B7D, 0x016B8F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Pahawh_Hmong}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Pahawh_Hmong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Pahawh_Hmong}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Pahawh_Hmong}"
 );
-assert(
-  /^\p{Script_Extensions=Hmng}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Hmng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Hmng}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Hmng}"
 );
-assert(
-  /^\p{scx=Pahawh_Hmong}+$/u.test(matchSymbols),
-  "`\\p{scx=Pahawh_Hmong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Pahawh_Hmong}+$/u,
+  matchSymbols,
+  "\\p{scx=Pahawh_Hmong}"
 );
-assert(
-  /^\p{scx=Hmng}+$/u.test(matchSymbols),
-  "`\\p{scx=Hmng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Hmng}+$/u,
+  matchSymbols,
+  "\\p{scx=Hmng}"
 );
 
 const nonMatchSymbols = buildString({
@@ -54,19 +58,23 @@ const nonMatchSymbols = buildString({
     [0x016B90, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Pahawh_Hmong}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Pahawh_Hmong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Pahawh_Hmong}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Pahawh_Hmong}"
 );
-assert(
-  /^\P{Script_Extensions=Hmng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Hmng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Hmng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Hmng}"
 );
-assert(
-  /^\P{scx=Pahawh_Hmong}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Pahawh_Hmong}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Pahawh_Hmong}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Pahawh_Hmong}"
 );
-assert(
-  /^\P{scx=Hmng}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Hmng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Hmng}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Hmng}"
 );

--- a/output/Script_Extensions_-_Palmyrene.js
+++ b/output/Script_Extensions_-_Palmyrene.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010860, 0x01087F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Palmyrene}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Palmyrene}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Palmyrene}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Palmyrene}"
 );
-assert(
-  /^\p{Script_Extensions=Palm}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Palm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Palm}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Palm}"
 );
-assert(
-  /^\p{scx=Palmyrene}+$/u.test(matchSymbols),
-  "`\\p{scx=Palmyrene}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Palmyrene}+$/u,
+  matchSymbols,
+  "\\p{scx=Palmyrene}"
 );
-assert(
-  /^\p{scx=Palm}+$/u.test(matchSymbols),
-  "`\\p{scx=Palm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Palm}+$/u,
+  matchSymbols,
+  "\\p{scx=Palm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010880, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Palmyrene}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Palmyrene}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Palmyrene}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Palmyrene}"
 );
-assert(
-  /^\P{Script_Extensions=Palm}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Palm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Palm}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Palm}"
 );
-assert(
-  /^\P{scx=Palmyrene}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Palmyrene}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Palmyrene}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Palmyrene}"
 );
-assert(
-  /^\P{scx=Palm}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Palm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Palm}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Palm}"
 );

--- a/output/Script_Extensions_-_Pau_Cin_Hau.js
+++ b/output/Script_Extensions_-_Pau_Cin_Hau.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x011AC0, 0x011AF8]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Pau_Cin_Hau}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Pau_Cin_Hau}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Pau_Cin_Hau}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Pau_Cin_Hau}"
 );
-assert(
-  /^\p{Script_Extensions=Pauc}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Pauc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Pauc}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Pauc}"
 );
-assert(
-  /^\p{scx=Pau_Cin_Hau}+$/u.test(matchSymbols),
-  "`\\p{scx=Pau_Cin_Hau}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Pau_Cin_Hau}+$/u,
+  matchSymbols,
+  "\\p{scx=Pau_Cin_Hau}"
 );
-assert(
-  /^\p{scx=Pauc}+$/u.test(matchSymbols),
-  "`\\p{scx=Pauc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Pauc}+$/u,
+  matchSymbols,
+  "\\p{scx=Pauc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x011AF9, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Pau_Cin_Hau}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Pau_Cin_Hau}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Pau_Cin_Hau}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Pau_Cin_Hau}"
 );
-assert(
-  /^\P{Script_Extensions=Pauc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Pauc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Pauc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Pauc}"
 );
-assert(
-  /^\P{scx=Pau_Cin_Hau}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Pau_Cin_Hau}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Pau_Cin_Hau}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Pau_Cin_Hau}"
 );
-assert(
-  /^\P{scx=Pauc}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Pauc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Pauc}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Pauc}"
 );

--- a/output/Script_Extensions_-_Phags_Pa.js
+++ b/output/Script_Extensions_-_Phags_Pa.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x00A840, 0x00A877]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Phags_Pa}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Phags_Pa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Phags_Pa}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Phags_Pa}"
 );
-assert(
-  /^\p{Script_Extensions=Phag}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Phag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Phag}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Phag}"
 );
-assert(
-  /^\p{scx=Phags_Pa}+$/u.test(matchSymbols),
-  "`\\p{scx=Phags_Pa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Phags_Pa}+$/u,
+  matchSymbols,
+  "\\p{scx=Phags_Pa}"
 );
-assert(
-  /^\p{scx=Phag}+$/u.test(matchSymbols),
-  "`\\p{scx=Phag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Phag}+$/u,
+  matchSymbols,
+  "\\p{scx=Phag}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Phags_Pa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Phags_Pa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Phags_Pa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Phags_Pa}"
 );
-assert(
-  /^\P{Script_Extensions=Phag}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Phag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Phag}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Phag}"
 );
-assert(
-  /^\P{scx=Phags_Pa}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Phags_Pa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Phags_Pa}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Phags_Pa}"
 );
-assert(
-  /^\P{scx=Phag}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Phag}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Phag}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Phag}"
 );

--- a/output/Script_Extensions_-_Phoenician.js
+++ b/output/Script_Extensions_-_Phoenician.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010900, 0x01091B]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Phoenician}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Phoenician}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Phoenician}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Phoenician}"
 );
-assert(
-  /^\p{Script_Extensions=Phnx}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Phnx}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Phnx}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Phnx}"
 );
-assert(
-  /^\p{scx=Phoenician}+$/u.test(matchSymbols),
-  "`\\p{scx=Phoenician}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Phoenician}+$/u,
+  matchSymbols,
+  "\\p{scx=Phoenician}"
 );
-assert(
-  /^\p{scx=Phnx}+$/u.test(matchSymbols),
-  "`\\p{scx=Phnx}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Phnx}+$/u,
+  matchSymbols,
+  "\\p{scx=Phnx}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x010920, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Phoenician}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Phoenician}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Phoenician}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Phoenician}"
 );
-assert(
-  /^\P{Script_Extensions=Phnx}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Phnx}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Phnx}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Phnx}"
 );
-assert(
-  /^\P{scx=Phoenician}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Phoenician}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Phoenician}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Phoenician}"
 );
-assert(
-  /^\P{scx=Phnx}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Phnx}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Phnx}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Phnx}"
 );

--- a/output/Script_Extensions_-_Psalter_Pahlavi.js
+++ b/output/Script_Extensions_-_Psalter_Pahlavi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x010BA9, 0x010BAF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Psalter_Pahlavi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Psalter_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Psalter_Pahlavi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Psalter_Pahlavi}"
 );
-assert(
-  /^\p{Script_Extensions=Phlp}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Phlp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Phlp}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Phlp}"
 );
-assert(
-  /^\p{scx=Psalter_Pahlavi}+$/u.test(matchSymbols),
-  "`\\p{scx=Psalter_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Psalter_Pahlavi}+$/u,
+  matchSymbols,
+  "\\p{scx=Psalter_Pahlavi}"
 );
-assert(
-  /^\p{scx=Phlp}+$/u.test(matchSymbols),
-  "`\\p{scx=Phlp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Phlp}+$/u,
+  matchSymbols,
+  "\\p{scx=Phlp}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x010BB0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Psalter_Pahlavi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Psalter_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Psalter_Pahlavi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Psalter_Pahlavi}"
 );
-assert(
-  /^\P{Script_Extensions=Phlp}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Phlp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Phlp}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Phlp}"
 );
-assert(
-  /^\P{scx=Psalter_Pahlavi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Psalter_Pahlavi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Psalter_Pahlavi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Psalter_Pahlavi}"
 );
-assert(
-  /^\P{scx=Phlp}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Phlp}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Phlp}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Phlp}"
 );

--- a/output/Script_Extensions_-_Rejang.js
+++ b/output/Script_Extensions_-_Rejang.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00A930, 0x00A953]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Rejang}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Rejang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Rejang}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Rejang}"
 );
-assert(
-  /^\p{Script_Extensions=Rjng}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Rjng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Rjng}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Rjng}"
 );
-assert(
-  /^\p{scx=Rejang}+$/u.test(matchSymbols),
-  "`\\p{scx=Rejang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Rejang}+$/u,
+  matchSymbols,
+  "\\p{scx=Rejang}"
 );
-assert(
-  /^\p{scx=Rjng}+$/u.test(matchSymbols),
-  "`\\p{scx=Rjng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Rjng}+$/u,
+  matchSymbols,
+  "\\p{scx=Rjng}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Rejang}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Rejang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Rejang}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Rejang}"
 );
-assert(
-  /^\P{Script_Extensions=Rjng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Rjng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Rjng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Rjng}"
 );
-assert(
-  /^\P{scx=Rejang}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Rejang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Rejang}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Rejang}"
 );
-assert(
-  /^\P{scx=Rjng}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Rjng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Rjng}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Rjng}"
 );

--- a/output/Script_Extensions_-_Runic.js
+++ b/output/Script_Extensions_-_Runic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0016EE, 0x0016F8]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Runic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Runic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Runic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Runic}"
 );
-assert(
-  /^\p{Script_Extensions=Runr}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Runr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Runr}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Runr}"
 );
-assert(
-  /^\p{scx=Runic}+$/u.test(matchSymbols),
-  "`\\p{scx=Runic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Runic}+$/u,
+  matchSymbols,
+  "\\p{scx=Runic}"
 );
-assert(
-  /^\p{scx=Runr}+$/u.test(matchSymbols),
-  "`\\p{scx=Runr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Runr}+$/u,
+  matchSymbols,
+  "\\p{scx=Runr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Runic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Runic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Runic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Runic}"
 );
-assert(
-  /^\P{Script_Extensions=Runr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Runr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Runr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Runr}"
 );
-assert(
-  /^\P{scx=Runic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Runic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Runic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Runic}"
 );
-assert(
-  /^\P{scx=Runr}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Runr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Runr}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Runr}"
 );

--- a/output/Script_Extensions_-_Samaritan.js
+++ b/output/Script_Extensions_-_Samaritan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x000830, 0x00083E]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Samaritan}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Samaritan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Samaritan}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Samaritan}"
 );
-assert(
-  /^\p{Script_Extensions=Samr}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Samr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Samr}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Samr}"
 );
-assert(
-  /^\p{scx=Samaritan}+$/u.test(matchSymbols),
-  "`\\p{scx=Samaritan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Samaritan}+$/u,
+  matchSymbols,
+  "\\p{scx=Samaritan}"
 );
-assert(
-  /^\p{scx=Samr}+$/u.test(matchSymbols),
-  "`\\p{scx=Samr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Samr}+$/u,
+  matchSymbols,
+  "\\p{scx=Samr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Samaritan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Samaritan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Samaritan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Samaritan}"
 );
-assert(
-  /^\P{Script_Extensions=Samr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Samr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Samr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Samr}"
 );
-assert(
-  /^\P{scx=Samaritan}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Samaritan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Samaritan}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Samaritan}"
 );
-assert(
-  /^\P{scx=Samr}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Samr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Samr}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Samr}"
 );

--- a/output/Script_Extensions_-_Saurashtra.js
+++ b/output/Script_Extensions_-_Saurashtra.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x00A8CE, 0x00A8D9]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Saurashtra}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Saurashtra}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Saurashtra}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Saurashtra}"
 );
-assert(
-  /^\p{Script_Extensions=Saur}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Saur}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Saur}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Saur}"
 );
-assert(
-  /^\p{scx=Saurashtra}+$/u.test(matchSymbols),
-  "`\\p{scx=Saurashtra}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Saurashtra}+$/u,
+  matchSymbols,
+  "\\p{scx=Saurashtra}"
 );
-assert(
-  /^\p{scx=Saur}+$/u.test(matchSymbols),
-  "`\\p{scx=Saur}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Saur}+$/u,
+  matchSymbols,
+  "\\p{scx=Saur}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Saurashtra}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Saurashtra}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Saurashtra}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Saurashtra}"
 );
-assert(
-  /^\P{Script_Extensions=Saur}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Saur}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Saur}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Saur}"
 );
-assert(
-  /^\P{scx=Saurashtra}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Saurashtra}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Saurashtra}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Saurashtra}"
 );
-assert(
-  /^\P{scx=Saur}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Saur}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Saur}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Saur}"
 );

--- a/output/Script_Extensions_-_Sharada.js
+++ b/output/Script_Extensions_-_Sharada.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -26,21 +26,25 @@ const matchSymbols = buildString({
     [0x0111D0, 0x0111DF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Sharada}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sharada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sharada}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sharada}"
 );
-assert(
-  /^\p{Script_Extensions=Shrd}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Shrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Shrd}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Shrd}"
 );
-assert(
-  /^\p{scx=Sharada}+$/u.test(matchSymbols),
-  "`\\p{scx=Sharada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sharada}+$/u,
+  matchSymbols,
+  "\\p{scx=Sharada}"
 );
-assert(
-  /^\p{scx=Shrd}+$/u.test(matchSymbols),
-  "`\\p{scx=Shrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Shrd}+$/u,
+  matchSymbols,
+  "\\p{scx=Shrd}"
 );
 
 const nonMatchSymbols = buildString({
@@ -59,19 +63,23 @@ const nonMatchSymbols = buildString({
     [0x0111E0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Sharada}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sharada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sharada}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sharada}"
 );
-assert(
-  /^\P{Script_Extensions=Shrd}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Shrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Shrd}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Shrd}"
 );
-assert(
-  /^\P{scx=Sharada}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sharada}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sharada}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sharada}"
 );
-assert(
-  /^\P{scx=Shrd}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Shrd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Shrd}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Shrd}"
 );

--- a/output/Script_Extensions_-_Shavian.js
+++ b/output/Script_Extensions_-_Shavian.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x010450, 0x01047F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Shavian}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Shavian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Shavian}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Shavian}"
 );
-assert(
-  /^\p{Script_Extensions=Shaw}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Shaw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Shaw}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Shaw}"
 );
-assert(
-  /^\p{scx=Shavian}+$/u.test(matchSymbols),
-  "`\\p{scx=Shavian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Shavian}+$/u,
+  matchSymbols,
+  "\\p{scx=Shavian}"
 );
-assert(
-  /^\p{scx=Shaw}+$/u.test(matchSymbols),
-  "`\\p{scx=Shaw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Shaw}+$/u,
+  matchSymbols,
+  "\\p{scx=Shaw}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x010480, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Shavian}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Shavian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Shavian}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Shavian}"
 );
-assert(
-  /^\P{Script_Extensions=Shaw}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Shaw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Shaw}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Shaw}"
 );
-assert(
-  /^\P{scx=Shavian}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Shavian}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Shavian}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Shavian}"
 );
-assert(
-  /^\P{scx=Shaw}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Shaw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Shaw}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Shaw}"
 );

--- a/output/Script_Extensions_-_Siddham.js
+++ b/output/Script_Extensions_-_Siddham.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0115B8, 0x0115DD]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Siddham}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Siddham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Siddham}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Siddham}"
 );
-assert(
-  /^\p{Script_Extensions=Sidd}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sidd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sidd}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sidd}"
 );
-assert(
-  /^\p{scx=Siddham}+$/u.test(matchSymbols),
-  "`\\p{scx=Siddham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Siddham}+$/u,
+  matchSymbols,
+  "\\p{scx=Siddham}"
 );
-assert(
-  /^\p{scx=Sidd}+$/u.test(matchSymbols),
-  "`\\p{scx=Sidd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sidd}+$/u,
+  matchSymbols,
+  "\\p{scx=Sidd}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0115DE, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Siddham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Siddham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Siddham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Siddham}"
 );
-assert(
-  /^\P{Script_Extensions=Sidd}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sidd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sidd}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sidd}"
 );
-assert(
-  /^\P{scx=Siddham}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Siddham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Siddham}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Siddham}"
 );
-assert(
-  /^\P{scx=Sidd}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sidd}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sidd}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sidd}"
 );

--- a/output/Script_Extensions_-_SignWriting.js
+++ b/output/Script_Extensions_-_SignWriting.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x01DAA1, 0x01DAAF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=SignWriting}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=SignWriting}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=SignWriting}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=SignWriting}"
 );
-assert(
-  /^\p{Script_Extensions=Sgnw}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sgnw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sgnw}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sgnw}"
 );
-assert(
-  /^\p{scx=SignWriting}+$/u.test(matchSymbols),
-  "`\\p{scx=SignWriting}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=SignWriting}+$/u,
+  matchSymbols,
+  "\\p{scx=SignWriting}"
 );
-assert(
-  /^\p{scx=Sgnw}+$/u.test(matchSymbols),
-  "`\\p{scx=Sgnw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sgnw}+$/u,
+  matchSymbols,
+  "\\p{scx=Sgnw}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x01DAB0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=SignWriting}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=SignWriting}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=SignWriting}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=SignWriting}"
 );
-assert(
-  /^\P{Script_Extensions=Sgnw}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sgnw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sgnw}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sgnw}"
 );
-assert(
-  /^\P{scx=SignWriting}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=SignWriting}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=SignWriting}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=SignWriting}"
 );
-assert(
-  /^\P{scx=Sgnw}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sgnw}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sgnw}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sgnw}"
 );

--- a/output/Script_Extensions_-_Sinhala.js
+++ b/output/Script_Extensions_-_Sinhala.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -33,21 +33,25 @@ const matchSymbols = buildString({
     [0x0111E1, 0x0111F4]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Sinhala}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sinhala}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sinhala}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sinhala}"
 );
-assert(
-  /^\p{Script_Extensions=Sinh}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sinh}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sinh}"
 );
-assert(
-  /^\p{scx=Sinhala}+$/u.test(matchSymbols),
-  "`\\p{scx=Sinhala}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sinhala}+$/u,
+  matchSymbols,
+  "\\p{scx=Sinhala}"
 );
-assert(
-  /^\p{scx=Sinh}+$/u.test(matchSymbols),
-  "`\\p{scx=Sinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sinh}+$/u,
+  matchSymbols,
+  "\\p{scx=Sinh}"
 );
 
 const nonMatchSymbols = buildString({
@@ -73,19 +77,23 @@ const nonMatchSymbols = buildString({
     [0x0111F5, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Sinhala}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sinhala}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sinhala}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sinhala}"
 );
-assert(
-  /^\P{Script_Extensions=Sinh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sinh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sinh}"
 );
-assert(
-  /^\P{scx=Sinhala}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sinhala}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sinhala}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sinhala}"
 );
-assert(
-  /^\P{scx=Sinh}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sinh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sinh}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sinh}"
 );

--- a/output/Script_Extensions_-_Sora_Sompeng.js
+++ b/output/Script_Extensions_-_Sora_Sompeng.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x0110F0, 0x0110F9]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Sora_Sompeng}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sora_Sompeng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sora_Sompeng}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sora_Sompeng}"
 );
-assert(
-  /^\p{Script_Extensions=Sora}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sora}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sora}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sora}"
 );
-assert(
-  /^\p{scx=Sora_Sompeng}+$/u.test(matchSymbols),
-  "`\\p{scx=Sora_Sompeng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sora_Sompeng}+$/u,
+  matchSymbols,
+  "\\p{scx=Sora_Sompeng}"
 );
-assert(
-  /^\p{scx=Sora}+$/u.test(matchSymbols),
-  "`\\p{scx=Sora}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sora}+$/u,
+  matchSymbols,
+  "\\p{scx=Sora}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x0110FA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Sora_Sompeng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sora_Sompeng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sora_Sompeng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sora_Sompeng}"
 );
-assert(
-  /^\P{Script_Extensions=Sora}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sora}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sora}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sora}"
 );
-assert(
-  /^\P{scx=Sora_Sompeng}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sora_Sompeng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sora_Sompeng}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sora_Sompeng}"
 );
-assert(
-  /^\P{scx=Sora}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sora}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sora}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sora}"
 );

--- a/output/Script_Extensions_-_Sundanese.js
+++ b/output/Script_Extensions_-_Sundanese.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x001CC0, 0x001CC7]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Sundanese}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sundanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sundanese}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sundanese}"
 );
-assert(
-  /^\p{Script_Extensions=Sund}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sund}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sund}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sund}"
 );
-assert(
-  /^\p{scx=Sundanese}+$/u.test(matchSymbols),
-  "`\\p{scx=Sundanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sundanese}+$/u,
+  matchSymbols,
+  "\\p{scx=Sundanese}"
 );
-assert(
-  /^\p{scx=Sund}+$/u.test(matchSymbols),
-  "`\\p{scx=Sund}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sund}+$/u,
+  matchSymbols,
+  "\\p{scx=Sund}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Sundanese}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sundanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sundanese}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sundanese}"
 );
-assert(
-  /^\P{Script_Extensions=Sund}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sund}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sund}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sund}"
 );
-assert(
-  /^\P{scx=Sundanese}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sundanese}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sundanese}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sundanese}"
 );
-assert(
-  /^\P{scx=Sund}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sund}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sund}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sund}"
 );

--- a/output/Script_Extensions_-_Syloti_Nagri.js
+++ b/output/Script_Extensions_-_Syloti_Nagri.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x00A800, 0x00A82B]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Syloti_Nagri}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Syloti_Nagri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Syloti_Nagri}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Syloti_Nagri}"
 );
-assert(
-  /^\p{Script_Extensions=Sylo}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Sylo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Sylo}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Sylo}"
 );
-assert(
-  /^\p{scx=Syloti_Nagri}+$/u.test(matchSymbols),
-  "`\\p{scx=Syloti_Nagri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Syloti_Nagri}+$/u,
+  matchSymbols,
+  "\\p{scx=Syloti_Nagri}"
 );
-assert(
-  /^\p{scx=Sylo}+$/u.test(matchSymbols),
-  "`\\p{scx=Sylo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Sylo}+$/u,
+  matchSymbols,
+  "\\p{scx=Sylo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Syloti_Nagri}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Syloti_Nagri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Syloti_Nagri}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Syloti_Nagri}"
 );
-assert(
-  /^\P{Script_Extensions=Sylo}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Sylo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Sylo}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Sylo}"
 );
-assert(
-  /^\P{scx=Syloti_Nagri}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Syloti_Nagri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Syloti_Nagri}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Syloti_Nagri}"
 );
-assert(
-  /^\P{scx=Sylo}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Sylo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Sylo}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Sylo}"
 );

--- a/output/Script_Extensions_-_Syriac.js
+++ b/output/Script_Extensions_-_Syriac.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -28,21 +28,25 @@ const matchSymbols = buildString({
     [0x00074D, 0x00074F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Syriac}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Syriac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Syriac}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Syriac}"
 );
-assert(
-  /^\p{Script_Extensions=Syrc}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Syrc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Syrc}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Syrc}"
 );
-assert(
-  /^\p{scx=Syriac}+$/u.test(matchSymbols),
-  "`\\p{scx=Syriac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Syriac}+$/u,
+  matchSymbols,
+  "\\p{scx=Syriac}"
 );
-assert(
-  /^\p{scx=Syrc}+$/u.test(matchSymbols),
-  "`\\p{scx=Syrc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Syrc}+$/u,
+  matchSymbols,
+  "\\p{scx=Syrc}"
 );
 
 const nonMatchSymbols = buildString({
@@ -63,19 +67,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Syriac}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Syriac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Syriac}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Syriac}"
 );
-assert(
-  /^\P{Script_Extensions=Syrc}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Syrc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Syrc}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Syrc}"
 );
-assert(
-  /^\P{scx=Syriac}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Syriac}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Syriac}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Syriac}"
 );
-assert(
-  /^\P{scx=Syrc}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Syrc}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Syrc}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Syrc}"
 );

--- a/output/Script_Extensions_-_Tagalog.js
+++ b/output/Script_Extensions_-_Tagalog.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x001735, 0x001736]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tagalog}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tagalog}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tagalog}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tagalog}"
 );
-assert(
-  /^\p{Script_Extensions=Tglg}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tglg}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tglg}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tglg}"
 );
-assert(
-  /^\p{scx=Tagalog}+$/u.test(matchSymbols),
-  "`\\p{scx=Tagalog}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tagalog}+$/u,
+  matchSymbols,
+  "\\p{scx=Tagalog}"
 );
-assert(
-  /^\p{scx=Tglg}+$/u.test(matchSymbols),
-  "`\\p{scx=Tglg}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tglg}+$/u,
+  matchSymbols,
+  "\\p{scx=Tglg}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tagalog}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tagalog}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tagalog}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tagalog}"
 );
-assert(
-  /^\P{Script_Extensions=Tglg}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tglg}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tglg}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tglg}"
 );
-assert(
-  /^\P{scx=Tagalog}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tagalog}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tagalog}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tagalog}"
 );
-assert(
-  /^\P{scx=Tglg}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tglg}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tglg}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tglg}"
 );

--- a/output/Script_Extensions_-_Tagbanwa.js
+++ b/output/Script_Extensions_-_Tagbanwa.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x001772, 0x001773]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tagbanwa}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tagbanwa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tagbanwa}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tagbanwa}"
 );
-assert(
-  /^\p{Script_Extensions=Tagb}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tagb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tagb}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tagb}"
 );
-assert(
-  /^\p{scx=Tagbanwa}+$/u.test(matchSymbols),
-  "`\\p{scx=Tagbanwa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tagbanwa}+$/u,
+  matchSymbols,
+  "\\p{scx=Tagbanwa}"
 );
-assert(
-  /^\p{scx=Tagb}+$/u.test(matchSymbols),
-  "`\\p{scx=Tagb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tagb}+$/u,
+  matchSymbols,
+  "\\p{scx=Tagb}"
 );
 
 const nonMatchSymbols = buildString({
@@ -52,19 +56,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tagbanwa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tagbanwa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tagbanwa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tagbanwa}"
 );
-assert(
-  /^\P{Script_Extensions=Tagb}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tagb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tagb}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tagb}"
 );
-assert(
-  /^\P{scx=Tagbanwa}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tagbanwa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tagbanwa}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tagbanwa}"
 );
-assert(
-  /^\P{scx=Tagb}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tagb}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tagb}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tagb}"
 );

--- a/output/Script_Extensions_-_Tai_Le.js
+++ b/output/Script_Extensions_-_Tai_Le.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x001970, 0x001974]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tai_Le}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tai_Le}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tai_Le}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tai_Le}"
 );
-assert(
-  /^\p{Script_Extensions=Tale}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tale}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tale}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tale}"
 );
-assert(
-  /^\p{scx=Tai_Le}+$/u.test(matchSymbols),
-  "`\\p{scx=Tai_Le}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tai_Le}+$/u,
+  matchSymbols,
+  "\\p{scx=Tai_Le}"
 );
-assert(
-  /^\p{scx=Tale}+$/u.test(matchSymbols),
-  "`\\p{scx=Tale}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tale}+$/u,
+  matchSymbols,
+  "\\p{scx=Tale}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tai_Le}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tai_Le}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tai_Le}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tai_Le}"
 );
-assert(
-  /^\P{Script_Extensions=Tale}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tale}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tale}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tale}"
 );
-assert(
-  /^\P{scx=Tai_Le}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tai_Le}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tai_Le}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tai_Le}"
 );
-assert(
-  /^\P{scx=Tale}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tale}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tale}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tale}"
 );

--- a/output/Script_Extensions_-_Tai_Tham.js
+++ b/output/Script_Extensions_-_Tai_Tham.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -23,21 +23,25 @@ const matchSymbols = buildString({
     [0x001AA0, 0x001AAD]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tai_Tham}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tai_Tham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tai_Tham}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tai_Tham}"
 );
-assert(
-  /^\p{Script_Extensions=Lana}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Lana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Lana}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Lana}"
 );
-assert(
-  /^\p{scx=Tai_Tham}+$/u.test(matchSymbols),
-  "`\\p{scx=Tai_Tham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tai_Tham}+$/u,
+  matchSymbols,
+  "\\p{scx=Tai_Tham}"
 );
-assert(
-  /^\p{scx=Lana}+$/u.test(matchSymbols),
-  "`\\p{scx=Lana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Lana}+$/u,
+  matchSymbols,
+  "\\p{scx=Lana}"
 );
 
 const nonMatchSymbols = buildString({
@@ -54,19 +58,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tai_Tham}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tai_Tham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tai_Tham}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tai_Tham}"
 );
-assert(
-  /^\P{Script_Extensions=Lana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Lana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Lana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Lana}"
 );
-assert(
-  /^\P{scx=Tai_Tham}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tai_Tham}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tai_Tham}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tai_Tham}"
 );
-assert(
-  /^\P{scx=Lana}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Lana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Lana}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Lana}"
 );

--- a/output/Script_Extensions_-_Tai_Viet.js
+++ b/output/Script_Extensions_-_Tai_Viet.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x00AADB, 0x00AADF]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tai_Viet}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tai_Viet}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tai_Viet}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tai_Viet}"
 );
-assert(
-  /^\p{Script_Extensions=Tavt}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tavt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tavt}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tavt}"
 );
-assert(
-  /^\p{scx=Tai_Viet}+$/u.test(matchSymbols),
-  "`\\p{scx=Tai_Viet}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tai_Viet}+$/u,
+  matchSymbols,
+  "\\p{scx=Tai_Viet}"
 );
-assert(
-  /^\p{scx=Tavt}+$/u.test(matchSymbols),
-  "`\\p{scx=Tavt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tavt}+$/u,
+  matchSymbols,
+  "\\p{scx=Tavt}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tai_Viet}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tai_Viet}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tai_Viet}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tai_Viet}"
 );
-assert(
-  /^\P{Script_Extensions=Tavt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tavt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tavt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tavt}"
 );
-assert(
-  /^\P{scx=Tai_Viet}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tai_Viet}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tai_Viet}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tai_Viet}"
 );
-assert(
-  /^\P{scx=Tavt}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tavt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tavt}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tavt}"
 );

--- a/output/Script_Extensions_-_Takri.js
+++ b/output/Script_Extensions_-_Takri.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x0116C0, 0x0116C9]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Takri}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Takri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Takri}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Takri}"
 );
-assert(
-  /^\p{Script_Extensions=Takr}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Takr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Takr}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Takr}"
 );
-assert(
-  /^\p{scx=Takri}+$/u.test(matchSymbols),
-  "`\\p{scx=Takri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Takri}+$/u,
+  matchSymbols,
+  "\\p{scx=Takri}"
 );
-assert(
-  /^\p{scx=Takr}+$/u.test(matchSymbols),
-  "`\\p{scx=Takr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Takr}+$/u,
+  matchSymbols,
+  "\\p{scx=Takr}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x0116CA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Takri}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Takri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Takri}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Takri}"
 );
-assert(
-  /^\P{Script_Extensions=Takr}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Takr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Takr}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Takr}"
 );
-assert(
-  /^\P{scx=Takri}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Takri}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Takri}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Takri}"
 );
-assert(
-  /^\P{scx=Takr}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Takr}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Takr}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Takr}"
 );

--- a/output/Script_Extensions_-_Tamil.js
+++ b/output/Script_Extensions_-_Tamil.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -41,21 +41,25 @@ const matchSymbols = buildString({
     [0x000BE6, 0x000BFA]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tamil}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tamil}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tamil}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tamil}"
 );
-assert(
-  /^\p{Script_Extensions=Taml}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Taml}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Taml}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Taml}"
 );
-assert(
-  /^\p{scx=Tamil}+$/u.test(matchSymbols),
-  "`\\p{scx=Tamil}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tamil}+$/u,
+  matchSymbols,
+  "\\p{scx=Tamil}"
 );
-assert(
-  /^\p{scx=Taml}+$/u.test(matchSymbols),
-  "`\\p{scx=Taml}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Taml}+$/u,
+  matchSymbols,
+  "\\p{scx=Taml}"
 );
 
 const nonMatchSymbols = buildString({
@@ -89,19 +93,23 @@ const nonMatchSymbols = buildString({
     [0x01133D, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tamil}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tamil}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tamil}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tamil}"
 );
-assert(
-  /^\P{Script_Extensions=Taml}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Taml}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Taml}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Taml}"
 );
-assert(
-  /^\P{scx=Tamil}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tamil}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tamil}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tamil}"
 );
-assert(
-  /^\P{scx=Taml}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Taml}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Taml}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Taml}"
 );

--- a/output/Script_Extensions_-_Tangut.js
+++ b/output/Script_Extensions_-_Tangut.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x018800, 0x018AF2]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tangut}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tangut}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tangut}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tangut}"
 );
-assert(
-  /^\p{Script_Extensions=Tang}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tang}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tang}"
 );
-assert(
-  /^\p{scx=Tangut}+$/u.test(matchSymbols),
-  "`\\p{scx=Tangut}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tangut}+$/u,
+  matchSymbols,
+  "\\p{scx=Tangut}"
 );
-assert(
-  /^\p{scx=Tang}+$/u.test(matchSymbols),
-  "`\\p{scx=Tang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tang}+$/u,
+  matchSymbols,
+  "\\p{scx=Tang}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x018AF3, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tangut}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tangut}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tangut}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tangut}"
 );
-assert(
-  /^\P{Script_Extensions=Tang}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tang}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tang}"
 );
-assert(
-  /^\P{scx=Tangut}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tangut}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tangut}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tangut}"
 );
-assert(
-  /^\P{scx=Tang}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tang}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tang}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tang}"
 );

--- a/output/Script_Extensions_-_Telugu.js
+++ b/output/Script_Extensions_-_Telugu.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -35,21 +35,25 @@ const matchSymbols = buildString({
     [0x000C78, 0x000C7F]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Telugu}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Telugu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Telugu}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Telugu}"
 );
-assert(
-  /^\p{Script_Extensions=Telu}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Telu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Telu}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Telu}"
 );
-assert(
-  /^\p{scx=Telugu}+$/u.test(matchSymbols),
-  "`\\p{scx=Telugu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Telugu}+$/u,
+  matchSymbols,
+  "\\p{scx=Telugu}"
 );
-assert(
-  /^\p{scx=Telu}+$/u.test(matchSymbols),
-  "`\\p{scx=Telu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Telu}+$/u,
+  matchSymbols,
+  "\\p{scx=Telu}"
 );
 
 const nonMatchSymbols = buildString({
@@ -77,19 +81,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Telugu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Telugu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Telugu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Telugu}"
 );
-assert(
-  /^\P{Script_Extensions=Telu}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Telu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Telu}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Telu}"
 );
-assert(
-  /^\P{scx=Telugu}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Telugu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Telugu}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Telugu}"
 );
-assert(
-  /^\P{scx=Telu}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Telu}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Telu}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Telu}"
 );

--- a/output/Script_Extensions_-_Thaana.js
+++ b/output/Script_Extensions_-_Thaana.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -26,21 +26,25 @@ const matchSymbols = buildString({
     [0x000780, 0x0007B1]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Thaana}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Thaana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Thaana}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Thaana}"
 );
-assert(
-  /^\p{Script_Extensions=Thaa}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Thaa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Thaa}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Thaa}"
 );
-assert(
-  /^\p{scx=Thaana}+$/u.test(matchSymbols),
-  "`\\p{scx=Thaana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Thaana}+$/u,
+  matchSymbols,
+  "\\p{scx=Thaana}"
 );
-assert(
-  /^\p{scx=Thaa}+$/u.test(matchSymbols),
-  "`\\p{scx=Thaa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Thaa}+$/u,
+  matchSymbols,
+  "\\p{scx=Thaa}"
 );
 
 const nonMatchSymbols = buildString({
@@ -58,19 +62,23 @@ const nonMatchSymbols = buildString({
     [0x00FDFE, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Thaana}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Thaana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Thaana}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Thaana}"
 );
-assert(
-  /^\P{Script_Extensions=Thaa}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Thaa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Thaa}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Thaa}"
 );
-assert(
-  /^\P{scx=Thaana}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Thaana}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Thaana}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Thaana}"
 );
-assert(
-  /^\P{scx=Thaa}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Thaa}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Thaa}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Thaa}"
 );

--- a/output/Script_Extensions_-_Thai.js
+++ b/output/Script_Extensions_-_Thai.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -20,21 +20,25 @@ const matchSymbols = buildString({
     [0x000E40, 0x000E5B]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Thai}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Thai}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Thai}"
 );
-assert(
-  /^\p{Script_Extensions=Thai}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Thai}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Thai}"
 );
-assert(
-  /^\p{scx=Thai}+$/u.test(matchSymbols),
-  "`\\p{scx=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Thai}+$/u,
+  matchSymbols,
+  "\\p{scx=Thai}"
 );
-assert(
-  /^\p{scx=Thai}+$/u.test(matchSymbols),
-  "`\\p{scx=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Thai}+$/u,
+  matchSymbols,
+  "\\p{scx=Thai}"
 );
 
 const nonMatchSymbols = buildString({
@@ -47,19 +51,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Thai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Thai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Thai}"
 );
-assert(
-  /^\P{Script_Extensions=Thai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Thai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Thai}"
 );
-assert(
-  /^\P{scx=Thai}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Thai}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Thai}"
 );
-assert(
-  /^\P{scx=Thai}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Thai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Thai}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Thai}"
 );

--- a/output/Script_Extensions_-_Tibetan.js
+++ b/output/Script_Extensions_-_Tibetan.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -25,21 +25,25 @@ const matchSymbols = buildString({
     [0x000FD9, 0x000FDA]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tibetan}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tibetan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tibetan}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tibetan}"
 );
-assert(
-  /^\p{Script_Extensions=Tibt}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tibt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tibt}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tibt}"
 );
-assert(
-  /^\p{scx=Tibetan}+$/u.test(matchSymbols),
-  "`\\p{scx=Tibetan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tibetan}+$/u,
+  matchSymbols,
+  "\\p{scx=Tibetan}"
 );
-assert(
-  /^\p{scx=Tibt}+$/u.test(matchSymbols),
-  "`\\p{scx=Tibt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tibt}+$/u,
+  matchSymbols,
+  "\\p{scx=Tibt}"
 );
 
 const nonMatchSymbols = buildString({
@@ -58,19 +62,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tibetan}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tibetan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tibetan}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tibetan}"
 );
-assert(
-  /^\P{Script_Extensions=Tibt}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tibt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tibt}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tibt}"
 );
-assert(
-  /^\P{scx=Tibetan}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tibetan}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tibetan}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tibetan}"
 );
-assert(
-  /^\P{scx=Tibt}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tibt}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tibt}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tibt}"
 );

--- a/output/Script_Extensions_-_Tifinagh.js
+++ b/output/Script_Extensions_-_Tifinagh.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x002D6F, 0x002D70]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tifinagh}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tifinagh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tifinagh}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tifinagh}"
 );
-assert(
-  /^\p{Script_Extensions=Tfng}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tfng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tfng}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tfng}"
 );
-assert(
-  /^\p{scx=Tifinagh}+$/u.test(matchSymbols),
-  "`\\p{scx=Tifinagh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tifinagh}+$/u,
+  matchSymbols,
+  "\\p{scx=Tifinagh}"
 );
-assert(
-  /^\p{scx=Tfng}+$/u.test(matchSymbols),
-  "`\\p{scx=Tfng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tfng}+$/u,
+  matchSymbols,
+  "\\p{scx=Tfng}"
 );
 
 const nonMatchSymbols = buildString({
@@ -50,19 +54,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tifinagh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tifinagh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tifinagh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tifinagh}"
 );
-assert(
-  /^\P{Script_Extensions=Tfng}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tfng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tfng}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tfng}"
 );
-assert(
-  /^\P{scx=Tifinagh}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tifinagh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tifinagh}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tifinagh}"
 );
-assert(
-  /^\P{scx=Tfng}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tfng}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tfng}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tfng}"
 );

--- a/output/Script_Extensions_-_Tirhuta.js
+++ b/output/Script_Extensions_-_Tirhuta.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -22,21 +22,25 @@ const matchSymbols = buildString({
     [0x0114D0, 0x0114D9]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Tirhuta}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tirhuta}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tirhuta}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tirhuta}"
 );
-assert(
-  /^\p{Script_Extensions=Tirh}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Tirh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Tirh}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Tirh}"
 );
-assert(
-  /^\p{scx=Tirhuta}+$/u.test(matchSymbols),
-  "`\\p{scx=Tirhuta}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tirhuta}+$/u,
+  matchSymbols,
+  "\\p{scx=Tirhuta}"
 );
-assert(
-  /^\p{scx=Tirh}+$/u.test(matchSymbols),
-  "`\\p{scx=Tirh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Tirh}+$/u,
+  matchSymbols,
+  "\\p{scx=Tirh}"
 );
 
 const nonMatchSymbols = buildString({
@@ -51,19 +55,23 @@ const nonMatchSymbols = buildString({
     [0x0114DA, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Tirhuta}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tirhuta}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tirhuta}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tirhuta}"
 );
-assert(
-  /^\P{Script_Extensions=Tirh}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Tirh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Tirh}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Tirh}"
 );
-assert(
-  /^\P{scx=Tirhuta}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tirhuta}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tirhuta}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tirhuta}"
 );
-assert(
-  /^\P{scx=Tirh}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Tirh}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Tirh}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Tirh}"
 );

--- a/output/Script_Extensions_-_Ugaritic.js
+++ b/output/Script_Extensions_-_Ugaritic.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x010380, 0x01039D]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Ugaritic}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ugaritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ugaritic}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ugaritic}"
 );
-assert(
-  /^\p{Script_Extensions=Ugar}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Ugar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Ugar}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Ugar}"
 );
-assert(
-  /^\p{scx=Ugaritic}+$/u.test(matchSymbols),
-  "`\\p{scx=Ugaritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ugaritic}+$/u,
+  matchSymbols,
+  "\\p{scx=Ugaritic}"
 );
-assert(
-  /^\p{scx=Ugar}+$/u.test(matchSymbols),
-  "`\\p{scx=Ugar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Ugar}+$/u,
+  matchSymbols,
+  "\\p{scx=Ugar}"
 );
 
 const nonMatchSymbols = buildString({
@@ -49,19 +53,23 @@ const nonMatchSymbols = buildString({
     [0x0103A0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Ugaritic}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ugaritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ugaritic}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ugaritic}"
 );
-assert(
-  /^\P{Script_Extensions=Ugar}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Ugar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Ugar}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Ugar}"
 );
-assert(
-  /^\P{scx=Ugaritic}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ugaritic}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ugaritic}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ugaritic}"
 );
-assert(
-  /^\P{scx=Ugar}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Ugar}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Ugar}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Ugar}"
 );

--- a/output/Script_Extensions_-_Vai.js
+++ b/output/Script_Extensions_-_Vai.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -19,21 +19,25 @@ const matchSymbols = buildString({
     [0x00A500, 0x00A62B]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Vai}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Vai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Vai}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Vai}"
 );
-assert(
-  /^\p{Script_Extensions=Vaii}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Vaii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Vaii}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Vaii}"
 );
-assert(
-  /^\p{scx=Vai}+$/u.test(matchSymbols),
-  "`\\p{scx=Vai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Vai}+$/u,
+  matchSymbols,
+  "\\p{scx=Vai}"
 );
-assert(
-  /^\p{scx=Vaii}+$/u.test(matchSymbols),
-  "`\\p{scx=Vaii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Vaii}+$/u,
+  matchSymbols,
+  "\\p{scx=Vaii}"
 );
 
 const nonMatchSymbols = buildString({
@@ -45,19 +49,23 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Vai}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Vai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Vai}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Vai}"
 );
-assert(
-  /^\P{Script_Extensions=Vaii}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Vaii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Vaii}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Vaii}"
 );
-assert(
-  /^\P{scx=Vai}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Vai}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Vai}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Vai}"
 );
-assert(
-  /^\P{scx=Vaii}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Vaii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Vaii}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Vaii}"
 );

--- a/output/Script_Extensions_-_Warang_Citi.js
+++ b/output/Script_Extensions_-_Warang_Citi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,21 +21,25 @@ const matchSymbols = buildString({
     [0x0118A0, 0x0118F2]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Warang_Citi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Warang_Citi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Warang_Citi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Warang_Citi}"
 );
-assert(
-  /^\p{Script_Extensions=Wara}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Wara}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Wara}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Wara}"
 );
-assert(
-  /^\p{scx=Warang_Citi}+$/u.test(matchSymbols),
-  "`\\p{scx=Warang_Citi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Warang_Citi}+$/u,
+  matchSymbols,
+  "\\p{scx=Warang_Citi}"
 );
-assert(
-  /^\p{scx=Wara}+$/u.test(matchSymbols),
-  "`\\p{scx=Wara}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Wara}+$/u,
+  matchSymbols,
+  "\\p{scx=Wara}"
 );
 
 const nonMatchSymbols = buildString({
@@ -48,19 +52,23 @@ const nonMatchSymbols = buildString({
     [0x011900, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Warang_Citi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Warang_Citi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Warang_Citi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Warang_Citi}"
 );
-assert(
-  /^\P{Script_Extensions=Wara}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Wara}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Wara}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Wara}"
 );
-assert(
-  /^\P{scx=Warang_Citi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Warang_Citi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Warang_Citi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Warang_Citi}"
 );
-assert(
-  /^\P{scx=Wara}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Wara}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Wara}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Wara}"
 );

--- a/output/Script_Extensions_-_Yi.js
+++ b/output/Script_Extensions_-_Yi.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -26,21 +26,25 @@ const matchSymbols = buildString({
     [0x00FF61, 0x00FF65]
   ]
 });
-assert(
-  /^\p{Script_Extensions=Yi}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Yi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Yi}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Yi}"
 );
-assert(
-  /^\p{Script_Extensions=Yiii}+$/u.test(matchSymbols),
-  "`\\p{Script_Extensions=Yiii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Script_Extensions=Yiii}+$/u,
+  matchSymbols,
+  "\\p{Script_Extensions=Yiii}"
 );
-assert(
-  /^\p{scx=Yi}+$/u.test(matchSymbols),
-  "`\\p{scx=Yi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Yi}+$/u,
+  matchSymbols,
+  "\\p{scx=Yi}"
 );
-assert(
-  /^\p{scx=Yiii}+$/u.test(matchSymbols),
-  "`\\p{scx=Yiii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{scx=Yiii}+$/u,
+  matchSymbols,
+  "\\p{scx=Yiii}"
 );
 
 const nonMatchSymbols = buildString({
@@ -58,19 +62,23 @@ const nonMatchSymbols = buildString({
     [0x00FF66, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Script_Extensions=Yi}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Yi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Yi}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Yi}"
 );
-assert(
-  /^\P{Script_Extensions=Yiii}+$/u.test(nonMatchSymbols),
-  "`\\P{Script_Extensions=Yiii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Script_Extensions=Yiii}+$/u,
+  nonMatchSymbols,
+  "\\P{Script_Extensions=Yiii}"
 );
-assert(
-  /^\P{scx=Yi}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Yi}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Yi}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Yi}"
 );
-assert(
-  /^\P{scx=Yiii}+$/u.test(nonMatchSymbols),
-  "`\\P{scx=Yiii}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{scx=Yiii}+$/u,
+  nonMatchSymbols,
+  "\\P{scx=Yiii}"
 );

--- a/output/Sentence_Terminal.js
+++ b/output/Sentence_Terminal.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -85,13 +85,15 @@ const matchSymbols = buildString({
     [0x016B37, 0x016B38]
   ]
 });
-assert(
-  /^\p{Sentence_Terminal}+$/u.test(matchSymbols),
-  "`\\p{Sentence_Terminal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Sentence_Terminal}+$/u,
+  matchSymbols,
+  "\\p{Sentence_Terminal}"
 );
-assert(
-  /^\p{STerm}+$/u.test(matchSymbols),
-  "`\\p{STerm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{STerm}+$/u,
+  matchSymbols,
+  "\\p{STerm}"
 );
 
 const nonMatchSymbols = buildString({
@@ -169,11 +171,13 @@ const nonMatchSymbols = buildString({
     [0x01DA89, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Sentence_Terminal}+$/u.test(nonMatchSymbols),
-  "`\\P{Sentence_Terminal}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Sentence_Terminal}+$/u,
+  nonMatchSymbols,
+  "\\P{Sentence_Terminal}"
 );
-assert(
-  /^\P{STerm}+$/u.test(nonMatchSymbols),
-  "`\\P{STerm}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{STerm}+$/u,
+  nonMatchSymbols,
+  "\\P{STerm}"
 );

--- a/output/Soft_Dotted.js
+++ b/output/Soft_Dotted.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -50,13 +50,15 @@ const matchSymbols = buildString({
     [0x01D692, 0x01D693]
   ]
 });
-assert(
-  /^\p{Soft_Dotted}+$/u.test(matchSymbols),
-  "`\\p{Soft_Dotted}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Soft_Dotted}+$/u,
+  matchSymbols,
+  "\\p{Soft_Dotted}"
 );
-assert(
-  /^\p{SD}+$/u.test(matchSymbols),
-  "`\\p{SD}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{SD}+$/u,
+  matchSymbols,
+  "\\p{SD}"
 );
 
 const nonMatchSymbols = buildString({
@@ -99,11 +101,13 @@ const nonMatchSymbols = buildString({
     [0x01D694, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Soft_Dotted}+$/u.test(nonMatchSymbols),
-  "`\\P{Soft_Dotted}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Soft_Dotted}+$/u,
+  nonMatchSymbols,
+  "\\P{Soft_Dotted}"
 );
-assert(
-  /^\P{SD}+$/u.test(nonMatchSymbols),
-  "`\\P{SD}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{SD}+$/u,
+  nonMatchSymbols,
+  "\\P{SD}"
 );

--- a/output/Terminal_Punctuation.js
+++ b/output/Terminal_Punctuation.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -113,13 +113,15 @@ const matchSymbols = buildString({
     [0x01DA87, 0x01DA8A]
   ]
 });
-assert(
-  /^\p{Terminal_Punctuation}+$/u.test(matchSymbols),
-  "`\\p{Terminal_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Terminal_Punctuation}+$/u,
+  matchSymbols,
+  "\\p{Terminal_Punctuation}"
 );
-assert(
-  /^\p{Term}+$/u.test(matchSymbols),
-  "`\\p{Term}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Term}+$/u,
+  matchSymbols,
+  "\\p{Term}"
 );
 
 const nonMatchSymbols = buildString({
@@ -225,11 +227,13 @@ const nonMatchSymbols = buildString({
     [0x01DA8B, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Terminal_Punctuation}+$/u.test(nonMatchSymbols),
-  "`\\P{Terminal_Punctuation}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Terminal_Punctuation}+$/u,
+  nonMatchSymbols,
+  "\\P{Terminal_Punctuation}"
 );
-assert(
-  /^\P{Term}+$/u.test(nonMatchSymbols),
-  "`\\P{Term}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Term}+$/u,
+  nonMatchSymbols,
+  "\\P{Term}"
 );

--- a/output/Unified_Ideograph.js
+++ b/output/Unified_Ideograph.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -32,13 +32,15 @@ const matchSymbols = buildString({
     [0x02B820, 0x02CEA1]
   ]
 });
-assert(
-  /^\p{Unified_Ideograph}+$/u.test(matchSymbols),
-  "`\\p{Unified_Ideograph}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Unified_Ideograph}+$/u,
+  matchSymbols,
+  "\\p{Unified_Ideograph}"
 );
-assert(
-  /^\p{UIdeo}+$/u.test(matchSymbols),
-  "`\\p{UIdeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{UIdeo}+$/u,
+  matchSymbols,
+  "\\p{UIdeo}"
 );
 
 const nonMatchSymbols = buildString({
@@ -63,11 +65,13 @@ const nonMatchSymbols = buildString({
     [0x02CEA2, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Unified_Ideograph}+$/u.test(nonMatchSymbols),
-  "`\\P{Unified_Ideograph}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Unified_Ideograph}+$/u,
+  nonMatchSymbols,
+  "\\P{Unified_Ideograph}"
 );
-assert(
-  /^\P{UIdeo}+$/u.test(nonMatchSymbols),
-  "`\\P{UIdeo}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{UIdeo}+$/u,
+  nonMatchSymbols,
+  "\\P{UIdeo}"
 );

--- a/output/Uppercase.js
+++ b/output/Uppercase.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -651,13 +651,15 @@ const matchSymbols = buildString({
     [0x01F170, 0x01F189]
   ]
 });
-assert(
-  /^\p{Uppercase}+$/u.test(matchSymbols),
-  "`\\p{Uppercase}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Uppercase}+$/u,
+  matchSymbols,
+  "\\p{Uppercase}"
 );
-assert(
-  /^\p{Upper}+$/u.test(matchSymbols),
-  "`\\p{Upper}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Upper}+$/u,
+  matchSymbols,
+  "\\p{Upper}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1301,11 +1303,13 @@ const nonMatchSymbols = buildString({
     [0x01F18A, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Uppercase}+$/u.test(nonMatchSymbols),
-  "`\\P{Uppercase}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Uppercase}+$/u,
+  nonMatchSymbols,
+  "\\P{Uppercase}"
 );
-assert(
-  /^\P{Upper}+$/u.test(nonMatchSymbols),
-  "`\\P{Upper}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Upper}+$/u,
+  nonMatchSymbols,
+  "\\P{Upper}"
 );

--- a/output/Variation_Selector.js
+++ b/output/Variation_Selector.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -21,13 +21,15 @@ const matchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\p{Variation_Selector}+$/u.test(matchSymbols),
-  "`\\p{Variation_Selector}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{Variation_Selector}+$/u,
+  matchSymbols,
+  "\\p{Variation_Selector}"
 );
-assert(
-  /^\p{VS}+$/u.test(matchSymbols),
-  "`\\p{VS}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{VS}+$/u,
+  matchSymbols,
+  "\\p{VS}"
 );
 
 const nonMatchSymbols = buildString({
@@ -41,11 +43,13 @@ const nonMatchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{Variation_Selector}+$/u.test(nonMatchSymbols),
-  "`\\P{Variation_Selector}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{Variation_Selector}+$/u,
+  nonMatchSymbols,
+  "\\P{Variation_Selector}"
 );
-assert(
-  /^\P{VS}+$/u.test(nonMatchSymbols),
-  "`\\P{VS}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{VS}+$/u,
+  nonMatchSymbols,
+  "\\P{VS}"
 );

--- a/output/White_Space.js
+++ b/output/White_Space.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -29,13 +29,15 @@ const matchSymbols = buildString({
     [0x002028, 0x002029]
   ]
 });
-assert(
-  /^\p{White_Space}+$/u.test(matchSymbols),
-  "`\\p{White_Space}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{White_Space}+$/u,
+  matchSymbols,
+  "\\p{White_Space}"
 );
-assert(
-  /^\p{space}+$/u.test(matchSymbols),
-  "`\\p{space}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{space}+$/u,
+  matchSymbols,
+  "\\p{space}"
 );
 
 const nonMatchSymbols = buildString({
@@ -56,11 +58,13 @@ const nonMatchSymbols = buildString({
     [0x00E000, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{White_Space}+$/u.test(nonMatchSymbols),
-  "`\\P{White_Space}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{White_Space}+$/u,
+  nonMatchSymbols,
+  "\\P{White_Space}"
 );
-assert(
-  /^\P{space}+$/u.test(nonMatchSymbols),
-  "`\\P{space}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{space}+$/u,
+  nonMatchSymbols,
+  "\\P{space}"
 );

--- a/output/XID_Continue.js
+++ b/output/XID_Continue.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -702,13 +702,15 @@ const matchSymbols = buildString({
     [0x0E0100, 0x0E01EF]
   ]
 });
-assert(
-  /^\p{XID_Continue}+$/u.test(matchSymbols),
-  "`\\p{XID_Continue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{XID_Continue}+$/u,
+  matchSymbols,
+  "\\p{XID_Continue}"
 );
-assert(
-  /^\p{XIDC}+$/u.test(matchSymbols),
-  "`\\p{XIDC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{XIDC}+$/u,
+  matchSymbols,
+  "\\p{XIDC}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1403,11 +1405,13 @@ const nonMatchSymbols = buildString({
     [0x0E01F0, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{XID_Continue}+$/u.test(nonMatchSymbols),
-  "`\\P{XID_Continue}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{XID_Continue}+$/u,
+  nonMatchSymbols,
+  "\\P{XID_Continue}"
 );
-assert(
-  /^\P{XIDC}+$/u.test(nonMatchSymbols),
-  "`\\P{XIDC}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{XIDC}+$/u,
+  nonMatchSymbols,
+  "\\P{XIDC}"
 );

--- a/output/XID_Start.js
+++ b/output/XID_Start.js
@@ -10,7 +10,7 @@ info: |
   Unicode v9.0.0
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString({
@@ -597,13 +597,15 @@ const matchSymbols = buildString({
     [0x02F800, 0x02FA1D]
   ]
 });
-assert(
-  /^\p{XID_Start}+$/u.test(matchSymbols),
-  "`\\p{XID_Start}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{XID_Start}+$/u,
+  matchSymbols,
+  "\\p{XID_Start}"
 );
-assert(
-  /^\p{XIDS}+$/u.test(matchSymbols),
-  "`\\p{XIDS}` matches all proper symbols"
+testPropertyEscapes(
+  /^\p{XIDS}+$/u,
+  matchSymbols,
+  "\\p{XIDS}"
 );
 
 const nonMatchSymbols = buildString({
@@ -1193,11 +1195,13 @@ const nonMatchSymbols = buildString({
     [0x02FA1E, 0x10FFFF]
   ]
 });
-assert(
-  /^\P{XID_Start}+$/u.test(nonMatchSymbols),
-  "`\\P{XID_Start}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{XID_Start}+$/u,
+  nonMatchSymbols,
+  "\\P{XID_Start}"
 );
-assert(
-  /^\P{XIDS}+$/u.test(nonMatchSymbols),
-  "`\\P{XIDS}` matches all proper symbols"
+testPropertyEscapes(
+  /^\P{XIDS}+$/u,
+  nonMatchSymbols,
+  "\\P{XIDS}"
 );

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lodash.template": "^4.4.0",
     "regenerate": "^1.3.2",
     "regenerate-unicode-properties": "^5.0.2",
+    "string.prototype.padstart": "^3.0.0",
     "unicode-9.0.0": "^0.7.3",
     "unicode-property-aliases": "^1.1.1",
     "unicode-property-value-aliases": "^1.2.2"

--- a/templates/test.template
+++ b/templates/test.template
@@ -10,22 +10,24 @@ info: |
   Unicode v<%= unicodeVersion %>
 esid: sec-static-semantics-unicodematchproperty-p
 features: [regexp-unicode-property-escapes]
-includes: [buildString.js]
+includes: [regExpUtils.js]
 ---*/
 
 const matchSymbols = buildString(<%= matchSymbols %>);
-<% for (const expression of expressions) { %>assert(
-  /^\p{<%= expression %>}+$/u.test(matchSymbols),
-  "`\\p{<%= expression %>}` matches all proper symbols"
+<% for (const expression of expressions) { %>testPropertyEscapes(
+  /^\p{<%= expression %>}+$/u,
+  matchSymbols,
+  "\\p{<%= expression %>}"
 );
 <% } %>
 <% if (nonMatchSymbols) { %>
 const nonMatchSymbols = buildString(<%= nonMatchSymbols %>);
 <%
   for (const expression of expressions) {
-%>assert(
-  /^\P{<%= expression %>}+$/u.test(nonMatchSymbols),
-  "`\\P{<%= expression %>}` matches all proper symbols"
+%>testPropertyEscapes(
+  /^\P{<%= expression %>}+$/u,
+  nonMatchSymbols,
+  "\\P{<%= expression %>}"
 );
 <%
   }
@@ -33,7 +35,7 @@ const nonMatchSymbols = buildString(<%= nonMatchSymbols %>);
   for (const expression of expressions) {
 %>assert(
   !/\P{<%= expression %>}/u.test(""),
-  "`\\P{<%= expression %>}` matches nothing (not even the empty string)"
+  "`\\P{<%= expression %>}` should match nothing (not even the empty string)"
 );
 <%
   }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,9 @@
 const assert = require('assert');
 
-// `build-string.js` doesn’t export anything, so let’s `eval` it.
-eval(require('fs').readFileSync('./harness/buildString.js', 'utf8'));
+require('string.prototype.padstart').shim();
+
+// The script doesn’t export anything, so let’s `eval` it.
+eval(require('fs').readFileSync('./harness/regExpUtils.js', 'utf8'));
 
 const symbols = buildString({
 	loneCodePoints: [],
@@ -13,3 +15,10 @@ const symbols = buildString({
 });
 
 assert.equal([...symbols].length, 1113984);
+
+assert.throws(
+	() => {
+		testPropertyEscapes(/^b+$/, 'abc', '.');
+	},
+	/U\+000061/
+);


### PR DESCRIPTION
In case there’s no match, apply the regular expression on each code point of the string.

In case the string matches, no `assert`s are hit.

cc @littledan @leobalter